### PR TITLE
tvOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,10 @@ matrix:
     - os: osx
       compiler: clang
       env: TARGET="ios"
+    - os: osx
+      osx_image: xcode7.1
+      compiler: clang
+      env: TARGET="tvos"
   exclude:
     - compiler: gcc
 install:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -49,7 +49,7 @@ echoDots(){
     done
 }
 
-if [ "$TARGET" == "osx" ] || [ "$TARGET" == "ios" ] || [ "$TARGET" == "tvos" ];; then
+if [ "$TARGET" == "osx" ] || [ "$TARGET" == "ios" ] || [ "$TARGET" == "tvos" ]; then
     PARALLEL=4
 elif [ "$TARGET" == "android" ]; then
     PARALLEL=2

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -49,7 +49,7 @@ echoDots(){
     done
 }
 
-if [ "$TARGET" == "osx" ] || [ "$TARGET" == "ios" ]; then
+if [ "$TARGET" == "osx" ] || [ "$TARGET" == "ios" ] || [ "$TARGET" == "tvos" ];; then
     PARALLEL=4
 elif [ "$TARGET" == "android" ]; then
     PARALLEL=2


### PR DESCRIPTION
Travis Updates to include tvOS Build.

- Uses travis osx_image: xcode7.1 (for tvOS 9.0+ support). https://docs.travis-ci.com/user/languages/objective-c/ for the tvOS matrix.


@arturoc Also apothecary doesn't have issues turned on at the moment. I think we turned them off when we "closed" this repo.