### PR TITLE
update glfw and openssl

### DIFF
--- a/apothecary/formulas/glfw.sh
+++ b/apothecary/formulas/glfw.sh
@@ -9,7 +9,7 @@
 FORMULA_TYPES=( "osx" "vs" )
 
 # define the version by sha
-# VER=32f38b97d544eb2fd9a568e94e37830106417b51
+VER=32f38b97d544eb2fd9a568e94e37830106417b51
 
 # tools for git use
 GIT_URL=https://github.com/glfw/glfw.git

--- a/apothecary/formulas/openssl/openssl.sh
+++ b/apothecary/formulas/openssl/openssl.sh
@@ -5,7 +5,7 @@
 # define the version
 FORMULA_TYPES=( "osx" "vs" "msys2" "ios" "tvos" "android" )
 
-VER=1.0.2g
+VER=1.0.2h
 VERDIR=1.0.2
 CSTANDARD=gnu11 # c89 | c99 | c11 | gnu11
 COMPILER_TYPE=clang # clang, gcc


### PR DESCRIPTION
use glfw from main repo instead of our own patched version + update openssl since 1.0.2g is not available any more