### PR TITLE
updates for vs2017

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,29 +5,35 @@ environment:
     APPVEYOR_OS_NAME: windows
     CHERE_INVOKING: 1
   matrix:
-  #VisualStudio 2017 Building
+  # #VisualStudio 2017 64 bit Building
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  #     platform: x64
+  #     TARGET: vs
+  #     VS_VER: 15
+  #     ARCH: 64
+  #VisualStudio 2017 32 bit Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x64
       TARGET: vs
       VS_VER: 15
+      ARCH: 32
+  # MSYS2 Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x86
+      TARGET: msys2
+      ARCH: 32
+  #VisualStudio 2015 32 bit Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x86
+      VS_VER: 14
+      TARGET: vs
+      ARCH: 32
+  #VisualStudio 2015 64 bit Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      VS_VER: 14
+      TARGET: vs
       ARCH: 64
-  #MSYS2 Building
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x86
-  #     TARGET: msys2
-  #     ARCH: 32
-  # #VisualStudio 2015 32 bit Building
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x86
-  #     VS_VER: 14
-  #     TARGET: vs
-  #     ARCH: 32
-  # #VisualStudio 2015 64 bit Building
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x64
-  #     VS_VER: 14
-  #     TARGET: vs
-  #     ARCH: 64
 
 
 configuration: Debug
@@ -45,7 +51,7 @@ init:
 - if "%PLATFORM%_%VS_VER%"=="x64_14" call "%VS140COMNTOOLS%..\..\VC\vcvarsall" amd64
 - if "%TARGET%_%VS_VER%"=="vs_14" set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin;%PATH%
 # visual studio 2017
-# - if "%PLATFORM%_%VS_VER%"=="x86_15" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+- if "%PLATFORM%_%VS_VER%"=="x86_15" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
 - if "%PLATFORM%_%VS_VER%"=="x64_15" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 - if "%TARGET%_%VS_VER%"=="vs_15" set PATH=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin;C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\bin\HostX64\x64;%PATH%
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,26 +5,26 @@ environment:
     APPVEYOR_OS_NAME: windows
     CHERE_INVOKING: 1
   matrix:
-  # VisualStudio 2017 64 bit Building
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x64
-      TARGET: vs
-      VS_VER: 15
-      ARCH: 64
-      VS_NAME: 2017
-  # VisualStudio 2017 32 bit Building
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x86
-      TARGET: vs
-      VS_VER: 15
-      ARCH: 32
-      VS_NAME: 2017
-  # MSYS2 Building
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x86
-      TARGET: msys2
-      ARCH: 32
-      VS_NAME: 
+  # # VisualStudio 2017 64 bit Building
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  #     platform: x64
+  #     TARGET: vs
+  #     VS_VER: 15
+  #     ARCH: 64
+  #     VS_NAME: 2017
+  # # VisualStudio 2017 32 bit Building
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  #     platform: x86
+  #     TARGET: vs
+  #     VS_VER: 15
+  #     ARCH: 32
+  #     VS_NAME: 2017
+  # # MSYS2 Building
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x86
+  #     TARGET: msys2
+  #     ARCH: 32
+  #     VS_NAME: 
   #VisualStudio 2015 32 bit Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       platform: x86

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,22 +12,22 @@ environment:
       VS_VER: 15
       ARCH: 64
   #MSYS2 Building
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x86
-      TARGET: msys2
-      ARCH: 32
-  #VisualStudio 2015 32 bit Building
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x86
-      VS_VER: 14
-      TARGET: vs
-      ARCH: 32
-  #VisualStudio 2015 64 bit Building
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x64
-      VS_VER: 14
-      TARGET: vs
-      ARCH: 64
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x86
+  #     TARGET: msys2
+  #     ARCH: 32
+  # #VisualStudio 2015 32 bit Building
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x86
+  #     VS_VER: 14
+  #     TARGET: vs
+  #     ARCH: 32
+  # #VisualStudio 2015 64 bit Building
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x64
+  #     VS_VER: 14
+  #     TARGET: vs
+  #     ARCH: 64
 
 
 configuration: Debug

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,8 +28,8 @@ environment:
   #VisualStudio 2015 32 bit Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       platform: x86
-      VS_VER: 14
       TARGET: vs
+      VS_VER: 14
       ARCH: 32
       VS_NAME: vs2015
   # #VisualStudio 2015 64 bit Building

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,8 +45,8 @@ init:
 - if "%PLATFORM%_%VS_VER%"=="x64_14" call "%VS140COMNTOOLS%..\..\VC\vcvarsall" amd64
 - if "%TARGET%_%VS_VER%"=="vs_14" set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin;%PATH%
 # visual studio 2017
-# - if "%PLATFORM%_%VS_VER%"=="x86_15" call %comspec% /k "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
-- if "%PLATFORM%_%VS_VER%"=="x64_15" call %comspec% /k "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+# - if "%PLATFORM%_%VS_VER%"=="x86_15" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+- if "%PLATFORM%_%VS_VER%"=="x64_15" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 - if "%TARGET%_%VS_VER%"=="vs_15" set PATH=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin;C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\bin\HostX64\x64;%PATH%
 
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,36 +5,40 @@ environment:
     APPVEYOR_OS_NAME: windows
     CHERE_INVOKING: 1
   matrix:
-  # #VisualStudio 2017 64 bit Building
+  # # VisualStudio 2017 64 bit Building
   #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
   #     platform: x64
   #     TARGET: vs
   #     VS_VER: 15
   #     ARCH: 64
-  #VisualStudio 2017 32 bit Building
+  #     VS_NAME: vs2017
+  # VisualStudio 2017 32 bit Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x86
       TARGET: vs
       VS_VER: 15
       ARCH: 32
-  # MSYS2 Building
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x86
-      TARGET: msys2
-      ARCH: 32
+      VS_NAME: vs2017
+  # # MSYS2 Building
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x86
+  #     TARGET: msys2
+  #     ARCH: 32
+  #     VS_NAME: 
   #VisualStudio 2015 32 bit Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       platform: x86
       VS_VER: 14
       TARGET: vs
       ARCH: 32
-  #VisualStudio 2015 64 bit Building
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x64
-      VS_VER: 14
-      TARGET: vs
-      ARCH: 64
-
+      VS_NAME: vs2015
+  # #VisualStudio 2015 64 bit Building
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x64
+  #     VS_VER: 14
+  #     TARGET: vs
+  #     ARCH: 64
+  #     VS_NAME: vs2015
 
 configuration: Debug
 shallow_clone: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   #     ARCH: 64
   #VisualStudio 2017 32 bit Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x64
+      platform: x86
       TARGET: vs
       VS_VER: 15
       ARCH: 32

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,13 +5,13 @@ environment:
     APPVEYOR_OS_NAME: windows
     CHERE_INVOKING: 1
   matrix:
-  # # VisualStudio 2017 64 bit Building
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-  #     platform: x64
-  #     TARGET: vs
-  #     VS_VER: 15
-  #     ARCH: 64
-  #     VS_NAME: vs2017
+  # VisualStudio 2017 64 bit Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x64
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 64
+      VS_NAME: vs2017
   # VisualStudio 2017 32 bit Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x86
@@ -19,12 +19,12 @@ environment:
       VS_VER: 15
       ARCH: 32
       VS_NAME: vs2017
-  # # MSYS2 Building
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x86
-  #     TARGET: msys2
-  #     ARCH: 32
-  #     VS_NAME: 
+  # MSYS2 Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x86
+      TARGET: msys2
+      ARCH: 32
+      VS_NAME: 
   #VisualStudio 2015 32 bit Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       platform: x86
@@ -32,13 +32,13 @@ environment:
       VS_VER: 14
       ARCH: 32
       VS_NAME: vs2015
-  # #VisualStudio 2015 64 bit Building
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x64
-  #     VS_VER: 14
-  #     TARGET: vs
-  #     ARCH: 64
-  #     VS_NAME: vs2015
+  #VisualStudio 2015 64 bit Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      VS_VER: 14
+      TARGET: vs
+      ARCH: 64
+      VS_NAME: vs2015
 
 configuration: Debug
 shallow_clone: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,26 +5,26 @@ environment:
     APPVEYOR_OS_NAME: windows
     CHERE_INVOKING: 1
   matrix:
-  # # VisualStudio 2017 64 bit Building
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-  #     platform: x64
-  #     TARGET: vs
-  #     VS_VER: 15
-  #     ARCH: 64
-  #     VS_NAME: 2017
-  # # VisualStudio 2017 32 bit Building
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-  #     platform: x86
-  #     TARGET: vs
-  #     VS_VER: 15
-  #     ARCH: 32
-  #     VS_NAME: 2017
-  # # MSYS2 Building
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x86
-  #     TARGET: msys2
-  #     ARCH: 32
-  #     VS_NAME: 
+  # VisualStudio 2017 64 bit Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x64
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 64
+      VS_NAME: 2017
+  # VisualStudio 2017 32 bit Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x86
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 32
+      VS_NAME: 2017
+  # MSYS2 Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x86
+      TARGET: msys2
+      ARCH: 32
+      VS_NAME: 
   #VisualStudio 2015 32 bit Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       platform: x86

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,13 +5,13 @@ environment:
     APPVEYOR_OS_NAME: windows
     CHERE_INVOKING: 1
   matrix:
-  # # VisualStudio 2017 64 bit Building
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-  #     platform: x64
-  #     TARGET: vs
-  #     VS_VER: 15
-  #     ARCH: 64
-  #     VS_NAME: 2017
+  # VisualStudio 2017 64 bit Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x64
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 64
+      VS_NAME: 2017
   # VisualStudio 2017 32 bit Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x86
@@ -25,20 +25,20 @@ environment:
       TARGET: msys2
       ARCH: 32
       VS_NAME: 
-  # #VisualStudio 2015 32 bit Building
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x86
-  #     TARGET: vs
-  #     VS_VER: 14
-  #     ARCH: 32
-  #     VS_NAME: 2015
-  # #VisualStudio 2015 64 bit Building
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x64
-  #     VS_VER: 14
-  #     TARGET: vs
-  #     ARCH: 64
-  #     VS_NAME: 2015
+  #VisualStudio 2015 32 bit Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x86
+      TARGET: vs
+      VS_VER: 14
+      ARCH: 32
+      VS_NAME: 2015
+  #VisualStudio 2015 64 bit Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      VS_VER: 14
+      TARGET: vs
+      ARCH: 64
+      VS_NAME: 2015
 
 configuration: Debug
 shallow_clone: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,23 +1,34 @@
-version: 1.0.{build}
-os: Visual Studio 2015 RC
+version: 2.0.{build}
 
 environment:
   global:
     APPVEYOR_OS_NAME: windows
     CHERE_INVOKING: 1
   matrix:
+  #VisualStudio 2017 Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x64
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 64
   #MSYS2 Building
-    - platform: x86
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x86
       TARGET: msys2
       ARCH: 32
-
-  #VisualStudio Building
-    - platform: x86
+  #VisualStudio 2015 32 bit Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x86
+      VS_VER: 14
       TARGET: vs
       ARCH: 32
-    - platform: x64
+  #VisualStudio 2015 64 bit Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      VS_VER: 14
       TARGET: vs
       ARCH: 64
+
 
 configuration: Debug
 shallow_clone: true
@@ -26,15 +37,18 @@ clone_depth: 10
 init:
 - set MSYS2_PATH=c:\msys64
 - set PATH=%MSYS2_PATH%\usr\bin;%PATH%
-#- '%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm -Sy pacman"'
-#- '%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm -Syu"'
-#- '%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm -Su"'
 - '%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm -S unzip dos2unix gperf mingw-w64-i686-libxml2"'
 - if "%TARGET%_%PLATFORM%"=="msys2_x86" set MSYSTEM=MINGW32
 - if "%TARGET%_%PLATFORM%"=="msys2_x64" set MSYSTEM=MINGW64
-- if "%PLATFORM%"=="x86" call "%VS140COMNTOOLS%\vsvars32.bat"
-- if "%PLATFORM%"=="x64" call "%VS140COMNTOOLS%..\..\VC\vcvarsall" amd64
-- if "%TARGET%"=="vs" set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin;%PATH%
+# visual studio 2015
+- if "%PLATFORM%_%VS_VER%"=="x86_14" call "%VS140COMNTOOLS%\vsvars32.bat"
+- if "%PLATFORM%_%VS_VER%"=="x64_14" call "%VS140COMNTOOLS%..\..\VC\vcvarsall" amd64
+- if "%TARGET%_%VS_VER%"=="vs_14" set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin;%PATH%
+# visual studio 2017
+# - if "%PLATFORM%_%VS_VER%"=="x86_15" call %comspec% /k "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+- if "%PLATFORM%_%VS_VER%"=="x64_15" call %comspec% /k "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+- if "%TARGET%_%VS_VER%"=="vs_15" set PATH=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin;C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\bin\HostX64\x64;%PATH%
+
 
 build_script:
 - '%MSYS2_PATH%\usr\bin\bash -lc "scripts/build.sh"'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,40 +5,40 @@ environment:
     APPVEYOR_OS_NAME: windows
     CHERE_INVOKING: 1
   matrix:
-  # VisualStudio 2017 64 bit Building
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x64
-      TARGET: vs
-      VS_VER: 15
-      ARCH: 64
-      VS_NAME: vs2017
+  # # VisualStudio 2017 64 bit Building
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  #     platform: x64
+  #     TARGET: vs
+  #     VS_VER: 15
+  #     ARCH: 64
+  #     VS_NAME: 2017
   # VisualStudio 2017 32 bit Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x86
       TARGET: vs
       VS_VER: 15
       ARCH: 32
-      VS_NAME: vs2017
+      VS_NAME: 2017
   # MSYS2 Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       platform: x86
       TARGET: msys2
       ARCH: 32
       VS_NAME: 
-  #VisualStudio 2015 32 bit Building
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x86
-      TARGET: vs
-      VS_VER: 14
-      ARCH: 32
-      VS_NAME: vs2015
-  #VisualStudio 2015 64 bit Building
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x64
-      VS_VER: 14
-      TARGET: vs
-      ARCH: 64
-      VS_NAME: vs2015
+  # #VisualStudio 2015 32 bit Building
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x86
+  #     TARGET: vs
+  #     VS_VER: 14
+  #     ARCH: 32
+  #     VS_NAME: 2015
+  # #VisualStudio 2015 64 bit Building
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x64
+  #     VS_VER: 14
+  #     TARGET: vs
+  #     ARCH: 64
+  #     VS_NAME: 2015
 
 configuration: Debug
 shallow_clone: true

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -896,10 +896,10 @@ function vs-build() {
 	else
 		#statements
 		if [ $ARCH == 32 ] ; then
-			cmd.exe //c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
+			cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
 		elif [ $ARCH == 64 ] ; then
 			echo "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
-	        cmd.exe //c /s "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
+	        cmd.exe /c /s "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
 		fi
 	fi
 

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -856,10 +856,10 @@ function vs-build() {
 		echo "-- Searching for vs-build"
 		# vswhere is a utility to find the most recent vs compiler toolchain. it is 
 		# assumed to be installed at a fixed location
-		VSWHERE_EXE=`cmd.exe /c "echo %ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"`
+		VSWHERE_EXE=`cmd.exe //c "echo %ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" `
 		echo "-- Found vswhere: ${VSWHERE_EXE}"
 		# vswhere allows us to query the install dir of the ms build tools
-		VS_INSTALL_PATH=`cmd.exe /c "${VSWHERE_EXE}" -latest -products Microsoft.VisualStudio.Product.Community -requires Microsoft.VisualStudio.Component.VC.CoreIde -property installationPath`
+		VS_INSTALL_PATH=`cmd //c ${VSWHERE_EXE} -latest -products Microsoft.VisualStudio.Product.Community -requires Microsoft.VisualStudio.Component.VC.CoreIde -property installationPath`
 		echo "-- Found vs install path: ${VS_INSTALL_PATH}"
 		# msbuild is the tool used to build visual studio solutions
 		MSBUILD_PATH="${VS_INSTALL_PATH}\MSBuild\\${VS_VER}.0\Bin\MSBuild.exe"
@@ -903,10 +903,10 @@ function vs-upgrade() {
 		echo "-- Searching for devenv"
 		# vswhere is a utility to find the most recent vs compiler toolchain. it is 
 		# assumed to be installed at a fixed location
-		VSWHERE_EXE=`cmd.exe /c "echo %ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"`
+		VSWHERE_EXE=`cmd.exe //c "echo %ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" `
 		echo "-- Found vswhere: ${VSWHERE_EXE}"
 		# vswhere allows us to query the install dir of the ms build tools
-		VS_IDE_INSTALL_PATH=`cmd.exe /c "${VSWHERE_EXE}" -latest -products Microsoft.VisualStudio.Product.Community -requires Microsoft.VisualStudio.Component.VC.CoreIde -property installationPath`
+		VS_IDE_INSTALL_PATH=`cmd.exe //c "${VSWHERE_EXE}" -latest -products Microsoft.VisualStudio.Product.Community -requires Microsoft.VisualStudio.Component.VC.CoreIde -property installationPath`
 		echo "-- Found vs ide install path: ${VS_IDE_INSTALL_PATH}"
 		# msbuild is the tool used to build visual studio solutions
 		DEVENV_PATH="${VS_IDE_INSTALL_PATH}\Common7\IDE\devenv.exe"

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -81,8 +81,13 @@ if [ "$(${APOTHECARY_DIR}/ostype.sh)" == "osx" ]; then
     IOS_MIN_SDK_VER=7.0
 fi
 
-# used when building for vs
-VS_VER=15
+# used when building for vs - set to 15 if not set explicitly
+if [ -z ${VS_VER+x} ] ; then 
+	echo "VS_VER was unset - set to 15"
+	VS_VER=15
+else 
+	echo "VS_VER is set to '$VS_VER'"
+fi
 VS_64_BIT_ENV='VC\vcvarsall'
 
 # paths to android SDK, etc

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -82,7 +82,7 @@ if [ "$(${APOTHECARY_DIR}/ostype.sh)" == "osx" ]; then
 fi
 
 # used when building for vs
-VS_VER=14
+VS_VER=15
 VS_64_BIT_ENV='VC\vcvarsall'
 
 # paths to android SDK, etc

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -856,10 +856,10 @@ function vs-build() {
 		echo "-- Searching for vs-build"
 		# vswhere is a utility to find the most recent vs compiler toolchain. it is 
 		# assumed to be installed at a fixed location
-		VSWHERE_EXE=`cmd.exe //c "echo %ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" `
+		VSWHERE_EXE=`cmd.exe //c "echo %ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"`
 		echo "-- Found vswhere: ${VSWHERE_EXE}"
 		# vswhere allows us to query the install dir of the ms build tools
-		VS_INSTALL_PATH=`cmd //c ${VSWHERE_EXE} -latest -products Microsoft.VisualStudio.Product.Community -requires Microsoft.VisualStudio.Component.VC.CoreIde -property installationPath`
+		VS_INSTALL_PATH=`cmd //c "${VSWHERE_EXE}" -latest -products Microsoft.VisualStudio.Product.Community -requires Microsoft.VisualStudio.Component.VC.CoreIde -property installationPath`
 		echo "-- Found vs install path: ${VS_INSTALL_PATH}"
 		# msbuild is the tool used to build visual studio solutions
 		MSBUILD_PATH="${VS_INSTALL_PATH}\MSBuild\\${VS_VER}.0\Bin\MSBuild.exe"
@@ -875,7 +875,7 @@ function vs-build() {
 		echo "-- Build platform: $BUILD_CONFIGURATION"
 		echo "-- Build configuration: $BUILD_PLATFORM"
 
-		BUILD_EXEC="\"${MSBUILD_PATH}\" $1 /t:${2:-Build} /p:Platform=\"$BUILD_PLATFORM\" /p:Configuration=\"$BUILD_CONFIGURATION\""
+		BUILD_EXEC="\"${MSBUILD_PATH}\" \"$1\" /t:${2:-Build} /p:Platform=\"$BUILD_PLATFORM\" /p:Configuration=\"$BUILD_CONFIGURATION\""
 		echo "-- Build parameters: $BUILD_EXEC"
 
 		# we need to add some extra outer quotes, since cmd.exe will only remove the outermost quotes and we might 
@@ -885,10 +885,10 @@ function vs-build() {
 	else
 		#statements
 		if [ $ARCH == 32 ] ; then
-			cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
+			cmd.exe //c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
 		elif [ $ARCH == 64 ] ; then
 			echo "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
-	        cmd.exe /c /s "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
+	        cmd.exe //c /s "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
 		fi
 	fi
 
@@ -903,10 +903,10 @@ function vs-upgrade() {
 		echo "-- Searching for devenv"
 		# vswhere is a utility to find the most recent vs compiler toolchain. it is 
 		# assumed to be installed at a fixed location
-		VSWHERE_EXE=`cmd.exe //c "echo %ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" `
+		VSWHERE_EXE=`cmd.exe //c "echo %ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"`
 		echo "-- Found vswhere: ${VSWHERE_EXE}"
 		# vswhere allows us to query the install dir of the ms build tools
-		VS_IDE_INSTALL_PATH=`cmd.exe //c "${VSWHERE_EXE}" -latest -products Microsoft.VisualStudio.Product.Community -requires Microsoft.VisualStudio.Component.VC.CoreIde -property installationPath`
+		VS_IDE_INSTALL_PATH=`cmd //c "${VSWHERE_EXE}" -latest -products Microsoft.VisualStudio.Product.Community -requires Microsoft.VisualStudio.Component.VC.CoreIde -property installationPath`
 		echo "-- Found vs ide install path: ${VS_IDE_INSTALL_PATH}"
 		# msbuild is the tool used to build visual studio solutions
 		DEVENV_PATH="${VS_IDE_INSTALL_PATH}\Common7\IDE\devenv.exe"

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -872,8 +872,8 @@ function vs-build() {
 		BUILD_PLATFORM="$( cut -d '|' -f 2- <<< "${3:-Default|x64}" )"
 		BUILD_PLATFORM=$BUILD_PLATFORM
 
-		echo "-- Build platform: $BUILD_CONFIGURATION"
-		echo "-- Build configuration: $BUILD_PLATFORM"
+		echo "-- Build platform: $BUILD_PLATFORM"
+		echo "-- Build configuration: $BUILD_CONFIGURATION"
 
 		BUILD_EXEC="\"${MSBUILD_PATH}\" \"$1\" /t:${2:-Build} /p:Platform=\"$BUILD_PLATFORM\" /p:Configuration=\"$BUILD_CONFIGURATION\""
 		echo "-- Build parameters: $BUILD_EXEC"

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -859,7 +859,7 @@ function vs-build() {
 		VSWHERE_EXE=`cmd.exe /c "echo %ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"`
 		echo "-- Found vswhere: ${VSWHERE_EXE}"
 		# vswhere allows us to query the install dir of the ms build tools
-		VS_INSTALL_PATH=`"${VSWHERE_EXE}" -latest -products Microsoft.VisualStudio.Product.BuildTools -requires Microsoft.Component.MSBuild -property installationPath`
+		VS_INSTALL_PATH=`cmd.exe /c "${VSWHERE_EXE}" -latest -products Microsoft.VisualStudio.Product.Community -requires Microsoft.VisualStudio.Component.VC.CoreIde -property installationPath`
 		echo "-- Found vs install path: ${VS_INSTALL_PATH}"
 		# msbuild is the tool used to build visual studio solutions
 		MSBUILD_PATH="${VS_INSTALL_PATH}\MSBuild\\${VS_VER}.0\Bin\MSBuild.exe"
@@ -906,7 +906,7 @@ function vs-upgrade() {
 		VSWHERE_EXE=`cmd.exe /c "echo %ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"`
 		echo "-- Found vswhere: ${VSWHERE_EXE}"
 		# vswhere allows us to query the install dir of the ms build tools
-		VS_IDE_INSTALL_PATH=`"${VSWHERE_EXE}" -latest -products Microsoft.VisualStudio.Product.Community -requires Microsoft.VisualStudio.Component.VC.CoreIde -property installationPath`
+		VS_IDE_INSTALL_PATH=`cmd.exe /c "${VSWHERE_EXE}" -latest -products Microsoft.VisualStudio.Product.Community -requires Microsoft.VisualStudio.Component.VC.CoreIde -property installationPath`
 		echo "-- Found vs ide install path: ${VS_IDE_INSTALL_PATH}"
 		# msbuild is the tool used to build visual studio solutions
 		DEVENV_PATH="${VS_IDE_INSTALL_PATH}\Common7\IDE\devenv.exe"

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -850,20 +850,81 @@ function gitclone() {
 # example: vs-build "./tess2.sln" Build Debug
 # http://msdn.microsoft.com/library/vstudio/b20w810z.aspx
 function vs-build() {
-	if [ $ARCH == 32 ] ; then
-		cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
-	elif [ $ARCH == 64 ] ; then
-        cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
+
+	if [ $VS_VER -gt 14 ] ; then
+
+		echo "-- Searching for vs-build"
+		# vswhere is a utility to find the most recent vs compiler toolchain. it is 
+		# assumed to be installed at a fixed location
+		VSWHERE_EXE=`cmd.exe /c "echo %ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"`
+		echo "-- Found vswhere: ${VSWHERE_EXE}"
+		# vswhere allows us to query the install dir of the ms build tools
+		VS_INSTALL_PATH=`"${VSWHERE_EXE}" -latest -products Microsoft.VisualStudio.Product.BuildTools -requires Microsoft.Component.MSBuild -property installationPath`
+		echo "-- Found vs install path: ${VS_INSTALL_PATH}"
+		# msbuild is the tool used to build visual studio solutions
+		MSBUILD_PATH="${VS_INSTALL_PATH}\MSBuild\\${VS_VER}.0\Bin\MSBuild.exe"
+		echo "-- Found MSBuild path: ${MSBUILD_PATH}"
+		
+		# Cut part before '|' character of third parameter (which defaults to "Default|x64") and store it as BUILD_CONFIGURATION
+		BUILD_CONFIGURATION="$( cut -d '|' -f 1 <<< "${3:-Default|x64}" )"
+		BUILD_CONFIGURATION=$BUILD_CONFIGURATION
+		# Cut part after '|' character of third parameter (which defaults to "Default|x64") and store it as BUILD_PLATFORM
+		BUILD_PLATFORM="$( cut -d '|' -f 2- <<< "${3:-Default|x64}" )"
+		BUILD_PLATFORM=$BUILD_PLATFORM
+
+		echo "-- Build platform: $BUILD_CONFIGURATION"
+		echo "-- Build configuration: $BUILD_PLATFORM"
+
+		BUILD_EXEC="\"${MSBUILD_PATH}\" $1 /t:${2:-Build} /p:Platform=\"$BUILD_PLATFORM\" /p:Configuration=\"$BUILD_CONFIGURATION\""
+		echo "-- Build parameters: $BUILD_EXEC"
+
+		# we need to add some extra outer quotes, since cmd.exe will only remove the outermost quotes and we might 
+		# have some quotes inside the command.
+		cmd.exe /c "\"$BUILD_EXEC\""
+		
+	else
+		#statements
+		if [ $ARCH == 32 ] ; then
+			cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
+		elif [ $ARCH == 64 ] ; then
+			echo "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
+	        cmd.exe /c /s "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
+		fi
 	fi
+
 }
 
 # visual studio upgrader
 # http://msdn.microsoft.com/en-us/library/vstudio/w15a82ay(v=vs.110).aspx
 function vs-upgrade() {
-	if [ $ARCH == 32 ] ; then
-		cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && $VS_BUILD_TOOL $1 /Upgrade"
-	elif [ $ARCH == 64 ] ; then
-		cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && $VS_BUILD_TOOL $1 /Upgrade"
+	echo "-- vs-upgrade()"
+
+	if [ $VS_VER -gt 14 ] ; then
+		echo "-- Searching for devenv"
+		# vswhere is a utility to find the most recent vs compiler toolchain. it is 
+		# assumed to be installed at a fixed location
+		VSWHERE_EXE=`cmd.exe /c "echo %ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"`
+		echo "-- Found vswhere: ${VSWHERE_EXE}"
+		# vswhere allows us to query the install dir of the ms build tools
+		VS_IDE_INSTALL_PATH=`"${VSWHERE_EXE}" -latest -products Microsoft.VisualStudio.Product.Community -requires Microsoft.VisualStudio.Component.VC.CoreIde -property installationPath`
+		echo "-- Found vs ide install path: ${VS_IDE_INSTALL_PATH}"
+		# msbuild is the tool used to build visual studio solutions
+		DEVENV_PATH="${VS_IDE_INSTALL_PATH}\Common7\IDE\devenv.exe"
+		echo "-- Found devenv path: ${DEVENV_PATH}"
+		
+		UPGRADE_EXEC="\"${DEVENV_PATH}\" $1 /Upgrade"
+		echo "-- Upgrade parameters: $UPGRADE_EXEC"
+
+		# we need to add some extra outer quotes, since cmd.exe will only remove the outermost quotes and we might 
+		# have some quotes inside the command.
+		cmd.exe /c "\"$UPGRADE_EXEC\""
+		
+	else
+		if [ $ARCH == 32 ] ; then
+			cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && $VS_BUILD_TOOL $1 /Upgrade"
+		elif [ $ARCH == 64 ] ; then
+			cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && $VS_BUILD_TOOL $1 /Upgrade"
+		fi
 	fi
 }
 

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -864,12 +864,18 @@ function vs-build() {
 		# msbuild is the tool used to build visual studio solutions
 		MSBUILD_PATH="${VS_INSTALL_PATH}\MSBuild\\${VS_VER}.0\Bin\MSBuild.exe"
 		echo "-- Found MSBuild path: ${MSBUILD_PATH}"
-		
+
+		# define fallback build selection if vs-build was not called with enough parameters.
+		DEFAULT_BUILD="Release|x64"
+		if [ $ARCH == 32 ] ; then
+			DEFAULT_BUILD="Release|Win32"
+		fi
+
 		# Cut part before '|' character of third parameter (which defaults to "Default|x64") and store it as BUILD_CONFIGURATION
-		BUILD_CONFIGURATION="$( cut -d '|' -f 1 <<< "${3:-Default|x64}" )"
+		BUILD_CONFIGURATION="$( cut -d '|' -f 1 <<< "${3:-$DEFAULT_BUILD}" )"
 		BUILD_CONFIGURATION=$BUILD_CONFIGURATION
 		# Cut part after '|' character of third parameter (which defaults to "Default|x64") and store it as BUILD_PLATFORM
-		BUILD_PLATFORM="$( cut -d '|' -f 2- <<< "${3:-Default|x64}" )"
+		BUILD_PLATFORM="$( cut -d '|' -f 2- <<< "${3:-$DEFAULT_BUILD}" )"
 		BUILD_PLATFORM=$BUILD_PLATFORM
 
 		echo "-- Build platform: $BUILD_PLATFORM"

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -899,7 +899,7 @@ function vs-build() {
 			cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
 		elif [ $ARCH == 64 ] ; then
 			echo "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
-	        cmd.exe /c /s "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
+	        cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && $VS_BUILD_TOOL $1 /${2:-Build} \"${3:-Release}\""
 		fi
 	fi
 

--- a/apothecary/formulas/_depends/zlib.sh
+++ b/apothecary/formulas/_depends/zlib.sh
@@ -29,7 +29,7 @@ function build() {
 		unset TMP
 		unset TEMP
 		if [ $ARCH == 32 ] ; then
-			cmake -G "Visual Studio $VS_VER"
+			cmake -G "Visual Studio $VS_VER Win32"
 			vs-build "zlib.sln" Build "Release|Win32"
 		elif [ $ARCH == 64 ] ; then
 			cmake -G "Visual Studio $VS_VER Win64"

--- a/apothecary/formulas/_depends/zlib.sh
+++ b/apothecary/formulas/_depends/zlib.sh
@@ -29,7 +29,7 @@ function build() {
 		unset TMP
 		unset TEMP
 		if [ $ARCH == 32 ] ; then
-			cmake -G "Visual Studio $VS_VER Win32"
+			cmake -G "Visual Studio $VS_VER"
 			vs-build "zlib.sln" Build "Release|Win32"
 		elif [ $ARCH == 64 ] ; then
 			cmake -G "Visual Studio $VS_VER Win64"

--- a/apothecary/formulas/_depends/zlib.sh
+++ b/apothecary/formulas/_depends/zlib.sh
@@ -30,7 +30,7 @@ function build() {
 		unset TEMP
 		if [ $ARCH == 32 ] ; then
 			cmake -G "Visual Studio $VS_VER"
-			vs-build "zlib.sln"
+			vs-build "zlib.sln" Build "Release|Win32"
 		elif [ $ARCH == 64 ] ; then
 			cmake -G "Visual Studio $VS_VER Win64"
 			vs-build "zlib.sln" Build "Release|x64"

--- a/apothecary/formulas/boost/boost.sh
+++ b/apothecary/formulas/boost/boost.sh
@@ -8,7 +8,7 @@
 FORMULA_TYPES=( "osx" "ios" "tvos" "android" "emscripten" "vs" )
 
 # define the version
-VERSION=1.62.0
+VERSION=1.64.0
 VERSION_UNDERSCORES="$(echo "$VERSION" | sed 's/\./_/g')"
 TARBALL="boost_${VERSION_UNDERSCORES}.tar.gz"
 

--- a/apothecary/formulas/curl/curl.sh
+++ b/apothecary/formulas/curl/curl.sh
@@ -45,11 +45,17 @@ function build() {
 		export OPENSSL_LIBRARIES=$OF_LIBS_OPENSSL_ABS_PATH/lib/
 		PATH=$OPENSSL_LIBRARIES:$PATH cmd //c "projects\\generate.bat vc14"
 		cd projects/Windows/VC14/lib
-		if [ $ARCH == 32 ] ; then
-			PATH=$OPENSSL_LIBRARIES:$PATH vs-build libcurl.sln Build "LIB Release - LIB OpenSSL|Win32"
-		else
-			PATH=$OPENSSL_LIBRARIES:$PATH vs-build libcurl.sln Build "LIB Release - LIB OpenSSL|x64"
-		fi
+
+        # perform upgrade for vs2017, as project file will be for vs 2015
+        if [ $VS_VER -gt 14 ] ; then
+            vs-upgrade libcurl.sln
+        fi
+
+        if [ $ARCH == 32 ] ; then
+            PATH=$OPENSSL_LIBRARIES:$PATH vs-build libcurl.sln Build "LIB Release - LIB OpenSSL|Win32"
+        else
+            PATH=$OPENSSL_LIBRARIES:$PATH vs-build libcurl.sln Build "LIB Release - LIB OpenSSL|x64"
+        fi
 
 	elif [ "$TYPE" == "android" ]; then
 	    local BUILD_TO_DIR=$BUILD_DIR/curl/build/$TYPE/$ABI

--- a/apothecary/formulas/freetype/freetype.sh
+++ b/apothecary/formulas/freetype/freetype.sh
@@ -89,7 +89,9 @@ function build() {
 		unset TEMP
 		unset temp
 		cd builds/windows/vc2010 #this upgrades without issue to vs2015
-		vs-upgrade "freetype.sln"
+		
+		vs-upgrade freetype.sln
+
 		if [ "$ARCH" ==  "32" ] ; then
 			vs-build freetype.sln Build "Release|Win32"
 		elif [ "$ARCH" == "64" ] ; then

--- a/apothecary/formulas/libpng/libpng.sh
+++ b/apothecary/formulas/libpng/libpng.sh
@@ -56,6 +56,9 @@ function build() {
 		unset TMP
 		unset TEMP
 		cd projects/vs2015
+
+		vs-upgrade libpng.sln
+
 		if [ $ARCH == 32 ] ; then
 			vs-build libpng.sln Build "LIB Release|x86"
 		elif [ $ARCH == 64 ] ; then

--- a/apothecary/formulas/libxml2/libxml2.sh
+++ b/apothecary/formulas/libxml2/libxml2.sh
@@ -38,6 +38,9 @@ function build() {
 		unset TMP
 		unset TEMP
 		cd win32/VC10
+
+        vs-upgrade libxml2.vcxproj
+
 		if [ $ARCH == 32 ] ; then
 			vs-build libxml2.vcxproj Build "Release|Win32"
 		else

--- a/apothecary/formulas/opencv.sh
+++ b/apothecary/formulas/opencv.sh
@@ -168,8 +168,8 @@ function build() {
 		-DWITH_PNG=OFF \
 		-DWITH_OPENCL=OFF \
 		-DWITH_PVAPI=OFF  | tee ${LOG}
-		vs-build "OpenCV.sln"
-		vs-build "OpenCV.sln" Build "Debug"
+		vs-build "OpenCV.sln" Build "Release|Win32"
+		vs-build "OpenCV.sln" Build "Debug|Win32"
 	elif [ $ARCH == 64 ] ; then
 		mkdir -p build_vs_64
 		cd build_vs_64

--- a/apothecary/formulas/poco/buildwin.cmd
+++ b/apothecary/formulas/poco/buildwin.cmd
@@ -122,6 +122,7 @@ if %VS_VERSION%==vs100 (set VCPROJ_EXT=vcxproj)
 if %VS_VERSION%==vs110 (set VCPROJ_EXT=vcxproj)
 if %VS_VERSION%==vs120 (set VCPROJ_EXT=vcxproj)
 if %VS_VERSION%==vs140 (set VCPROJ_EXT=vcxproj)
+if %VS_VERSION%==vs150 (set VCPROJ_EXT=vcxproj)
 
 if "%8"=="" goto use_devenv
 set BUILD_TOOL=%8
@@ -132,6 +133,8 @@ if "%VS_VERSION%"=="vs100" (set BUILD_TOOL=msbuild)
 if "%VS_VERSION%"=="vs110" (set BUILD_TOOL=msbuild)
 if "%VS_VERSION%"=="vs120" (set BUILD_TOOL=msbuild)
 if "%VS_VERSION%"=="vs140" (set BUILD_TOOL=msbuild)
+if "%VS_VERSION%"=="vs150" (set BUILD_TOOL=msbuild)
+
 :use_custom
 if not "%BUILD_TOOL%"=="msbuild" (set USEENV=/useenv)
 if "%BUILD_TOOL%"=="msbuild" (
@@ -147,6 +150,7 @@ if "%VS_VERSION%"=="vs100" (goto msbuildok)
 if "%VS_VERSION%"=="vs110" (goto msbuildok)
 if "%VS_VERSION%"=="vs120" (goto msbuildok)
 if "%VS_VERSION%"=="vs140" (goto msbuildok)
+if "%VS_VERSION%"=="vs150" (goto msbuildok)
 if "%BUILD_TOOL%"=="msbuild" (
   echo "Cannot use msbuild with Visual Studio 2008 or earlier."
   exit /b 2
@@ -191,6 +195,7 @@ set USEENV=
 if %VS_VERSION%==vs110 (set EXTRASW=/m /p:VisualStudioVersion=11.0)
 if %VS_VERSION%==vs120 (set EXTRASW=/m /p:VisualStudioVersion=12.0)
 if %VS_VERSION%==vs140 (set EXTRASW=/m /p:VisualStudioVersion=14.0)
+if %VS_VERSION%==vs150 (set EXTRASW=/m /p:VisualStudioVersion=15.0)
 )
 
 rem SAMPLES [samples|nosamples]
@@ -597,7 +602,7 @@ exit /b 1
 echo Usage:
 echo ------
 echo buildwin VS_VERSION [ACTION] [LINKMODE] [CONFIGURATION] [PLATFORM] [SAMPLES] [TESTS] [TOOL]
-echo VS_VERSION:    "90|100|110|120|140"
+echo VS_VERSION:    "90|100|110|120|140|150"
 echo ACTION:        "build|rebuild|clean|upgrade"
 echo LINKMODE:      "static_mt|static_md|shared|all"
 echo CONFIGURATION: "release|debug|both"

--- a/apothecary/formulas/poco/poco.sh
+++ b/apothecary/formulas/poco/poco.sh
@@ -166,13 +166,22 @@ function build() {
 	elif [ "$TYPE" == "vs" ] ; then
 		unset TMP
 		unset TEMP
-		if [ $ARCH == 32 ] ; then
-			cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && buildwin.cmd ${VS_VER}0 upgrade static_md both Win32 nosamples notests"
-			cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && buildwin.cmd ${VS_VER}0 build static_md both Win32 nosamples notests"
-		elif [ $ARCH == 64 ] ; then
-			cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && buildwin.cmd ${VS_VER}0 upgrade static_md both x64 nosamples notests"
-			cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && buildwin.cmd ${VS_VER}0 build static_md both x64 nosamples notests"
+
+		if [[ $VS_VER -gt 14 ]]; then
+
+			cmd.exe /c "call \"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat\" && buildwin.cmd ${VS_VER}0 upgrade static_md both Win32 nosamples notests"			
+			cmd.exe /c "call \"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat\" && buildwin.cmd ${VS_VER}0 build static_md both Win32 nosamples notests"
+			else 
+
+			if [ $ARCH == 32 ] ; then
+				cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && buildwin.cmd ${VS_VER}0 upgrade static_md both Win32 nosamples notests"
+				cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && buildwin.cmd ${VS_VER}0 build static_md both Win32 nosamples notests"
+			elif [ $ARCH == 64 ] ; then
+				cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && buildwin.cmd ${VS_VER}0 upgrade static_md both x64 nosamples notests"
+				cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && buildwin.cmd ${VS_VER}0 build static_md both x64 nosamples notests"
+			fi
 		fi
+
 	elif [ "$TYPE" == "msys2" ] ; then
 	    cp $FORMULA_DIR/MinGWConfig64 build/config/MinGW
 

--- a/apothecary/formulas/poco/poco.sh
+++ b/apothecary/formulas/poco/poco.sh
@@ -169,8 +169,8 @@ function build() {
 
 		if [[ $VS_VER -gt 14 ]]; then
 
-			cmd.exe /c "call \"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat\" && buildwin.cmd ${VS_VER}0 upgrade static_md both Win32 nosamples notests"			
-			cmd.exe /c "call \"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat\" && buildwin.cmd ${VS_VER}0 build static_md both Win32 nosamples notests"
+			cmd.exe /c "call \"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat\" && buildwin.cmd ${VS_VER}0 upgrade static_md both x64 nosamples notests"			
+			cmd.exe /c "call \"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat\" && buildwin.cmd ${VS_VER}0 build static_md both x64 nosamples notests"
 			else 
 
 			if [ $ARCH == 32 ] ; then

--- a/apothecary/formulas/poco/poco.sh
+++ b/apothecary/formulas/poco/poco.sh
@@ -169,17 +169,23 @@ function build() {
 
 		if [[ $VS_VER -gt 14 ]]; then
 
-			cmd.exe /c "call \"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat\" && buildwin.cmd ${VS_VER}0 upgrade static_md both x64 nosamples notests"			
-			cmd.exe /c "call \"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat\" && buildwin.cmd ${VS_VER}0 build static_md both x64 nosamples notests"
+				if [ $ARCH == 32 ] ; then
+					cmd.exe /c "call \"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat\" && buildwin.cmd ${VS_VER}0 upgrade static_md both Win32 nosamples notests"			
+					cmd.exe /c "call \"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat\" && buildwin.cmd ${VS_VER}0 build static_md both Win32 nosamples notests"
+				elif [ $ARCH == 64 ] ; then
+					cmd.exe /c "call \"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat\" && buildwin.cmd ${VS_VER}0 upgrade static_md both x64 nosamples notests"			
+					cmd.exe /c "call \"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat\" && buildwin.cmd ${VS_VER}0 build static_md both x64 nosamples notests"
+				fi
+
 			else 
 
-			if [ $ARCH == 32 ] ; then
-				cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && buildwin.cmd ${VS_VER}0 upgrade static_md both Win32 nosamples notests"
-				cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && buildwin.cmd ${VS_VER}0 build static_md both Win32 nosamples notests"
-			elif [ $ARCH == 64 ] ; then
-				cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && buildwin.cmd ${VS_VER}0 upgrade static_md both x64 nosamples notests"
-				cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && buildwin.cmd ${VS_VER}0 build static_md both x64 nosamples notests"
-			fi
+				if [ $ARCH == 32 ] ; then
+					cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && buildwin.cmd ${VS_VER}0 upgrade static_md both Win32 nosamples notests"
+					cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%vsvars32.bat\" && buildwin.cmd ${VS_VER}0 build static_md both Win32 nosamples notests"
+				elif [ $ARCH == 64 ] ; then
+					cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && buildwin.cmd ${VS_VER}0 upgrade static_md both x64 nosamples notests"
+					cmd.exe /c "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && buildwin.cmd ${VS_VER}0 build static_md both x64 nosamples notests"
+				fi
 		fi
 
 	elif [ "$TYPE" == "msys2" ] ; then

--- a/apothecary/formulas/pugixml.sh
+++ b/apothecary/formulas/pugixml.sh
@@ -57,8 +57,8 @@ function build() {
 					vs-build "pugixml_vs2015.vcxproj" build "Release"
 					vs-build "pugixml_vs2015.vcxproj" build "Debug"
 			else
-					vs-build "pugixml_vs2015.vcxproj" build "Release"
-					vs-build "pugixml_vs2015.vcxproj" build "Debug"
+					vs-build "pugixml_vs2015.vcxproj" build "Release|x64"
+					vs-build "pugixml_vs2015.vcxproj" build "Debug|x64"
 			fi
 		fi
 

--- a/apothecary/formulas/pugixml.sh
+++ b/apothecary/formulas/pugixml.sh
@@ -44,8 +44,8 @@ function build() {
 		unset TEMP
 		cd scripts
 		if [ $ARCH == 32 ] ; then
-				vs-build pugixml_vs2015.vcxproj Build "Release|x86"
-				vs-build pugixml_vs2015.vcxproj Build "Debug|x86"
+				vs-build pugixml_vs2015.vcxproj Build "Release|Win32"
+				vs-build pugixml_vs2015.vcxproj Build "Debug|Win32"
 		else
 				vs-build pugixml_vs2015.vcxproj Build "Release|x64"
 				vs-build pugixml_vs2015.vcxproj Build "Debug|x64"

--- a/apothecary/formulas/pugixml.sh
+++ b/apothecary/formulas/pugixml.sh
@@ -43,13 +43,25 @@ function build() {
 		unset TMP
 		unset TEMP
 		cd scripts
-		if [ $ARCH == 32 ] ; then
-				vs-build pugixml_vs2015.vcxproj Build "Release|Win32"
-				vs-build pugixml_vs2015.vcxproj Build "Debug|Win32"
+
+		if [[ $VS_VER -gt 14 ]]; then
+			if [ $ARCH == 32 ] ; then
+					vs-build "pugixml_vs2015.vcxproj" build "Release|Win32"
+					vs-build "pugixml_vs2015.vcxproj" build "Debug|Win32"
+			else
+					vs-build "pugixml_vs2015.vcxproj" build "Release|x64"
+					vs-build "pugixml_vs2015.vcxproj" build "Debug|x64"
+			fi
 		else
-				vs-build pugixml_vs2015.vcxproj Build "Release|x64"
-				vs-build pugixml_vs2015.vcxproj Build "Debug|x64"
+			if [ $ARCH == 32 ] ; then
+					vs-build "pugixml_vs2015.vcxproj" build "Release"
+					vs-build "pugixml_vs2015.vcxproj" build "Debug"
+			else
+					vs-build "pugixml_vs2015.vcxproj" build "Release"
+					vs-build "pugixml_vs2015.vcxproj" build "Debug"
+			fi
 		fi
+
 	elif [ "$TYPE" == "android" ]; then
         source ../../android_configure.sh $ABI
 		# Compile the program

--- a/apothecary/formulas/rtAudio.sh
+++ b/apothecary/formulas/rtAudio.sh
@@ -86,8 +86,8 @@ function build() {
 			mkdir -p build_vs_32
 			cd build_vs_32
 			cmake .. -G "Visual Studio $VS_VER"  -DAUDIO_WINDOWS_WASAPI=ON -DAUDIO_WINDOWS_DS=ON -DAUDIO_WINDOWS_ASIO=ON
-			vs-build "rtaudio_static.vcxproj"
-			vs-build "rtaudio_static.vcxproj" Build "Debug"
+			vs-build "rtaudio_static.vcxproj" Build "Release|Win32"
+			vs-build "rtaudio_static.vcxproj" Build "Debug|Win32"
 		elif [ $ARCH == 64 ] ; then
 			mkdir -p build_vs_64
 			cd build_vs_64

--- a/apothecary/formulas/uriparser/uriparser.sh
+++ b/apothecary/formulas/uriparser/uriparser.sh
@@ -39,6 +39,11 @@ function build() {
 		unset TMP
 		unset TEMP
 		cd win32/vs2015
+
+		if [[ $VS_VER -gt 14 ]]; then
+			vs-upgrade uriparser.sln
+		fi
+
 		if [ $ARCH == 32 ] ; then
 			vs-build uriparser.sln Build "Release|Win32"
 		elif [ $ARCH == 64 ] ; then

--- a/apothecary/formulas/uriparser/vs2015/uriparser.vcxproj
+++ b/apothecary/formulas/uriparser/vs2015/uriparser.vcxproj
@@ -114,6 +114,7 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
     <Lib>
       <OutputFile>..\uriparser.lib</OutputFile>
@@ -128,6 +129,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
     <Lib>
       <OutputFile>..\uriparser.lib</OutputFile>

--- a/apothecary/formulas/videoInput.sh
+++ b/apothecary/formulas/videoInput.sh
@@ -35,8 +35,8 @@ function build() {
 		unset TEMP
 		cd VS-videoInputcompileAsLib
 		if [ $ARCH == 32 ] ; then
-			vs-build "videoInput.sln"
-			vs-build "videoInput.sln" Build "Debug"
+			vs-build "videoInput.sln" Build "Release|Win32"
+			vs-build "videoInput.sln" Build "Debug|Win32"
 		elif [ $ARCH == 64 ] ; then
 			vs-build "videoInput.sln" Build "Release|x64"
 			vs-build "videoInput.sln" Build "Debug|x64"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -153,7 +153,7 @@ cd $ROOT
 echo "Compressing libraries from $PWD"
 LIBS=$(ls | grep -v \.appveyor.yml | grep -v \.travis.yml | grep -v \.gitignore | grep -v apothecary | grep -v scripts)
 if [ ! -z ${APPVEYOR+x} ]; then
-	TARBALL=openFrameworksLibs_${APPVEYOR_REPO_BRANCH}_${TARGET}${ARCH}.zip
+	TARBALL=openFrameworksLibs_${APPVEYOR_REPO_BRANCH}_${TARGET}_${VS_NAME}${ARCH}.zip
 	7z a $TARBALL $LIBS
 else
 	TARBALL=openFrameworksLibs_${TRAVIS_BRANCH}_$TARGET$OPT$OPT2.tar.bz2

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -153,7 +153,7 @@ cd $ROOT
 echo "Compressing libraries from $PWD"
 LIBS=$(ls | grep -v \.appveyor.yml | grep -v \.travis.yml | grep -v \.gitignore | grep -v apothecary | grep -v scripts)
 if [ ! -z ${APPVEYOR+x} ]; then
-	TARBALL=openFrameworksLibs_${APPVEYOR_REPO_BRANCH}_${TARGET}_${VS_NAME}${ARCH}.zip
+	TARBALL=openFrameworksLibs_${APPVEYOR_REPO_BRANCH}_${TARGET}${VS_NAME}_${ARCH}.zip
 	7z a $TARBALL $LIBS
 else
 	TARBALL=openFrameworksLibs_${TRAVIS_BRANCH}_$TARGET$OPT$OPT2.tar.bz2


### PR DESCRIPTION
Updates to support visual studio 2017 compiler and toolchain to build dependencies using apothecary. The idea is to support vs2015 and vs2017 side-by side, using the variable $VS_VER to choose which version of the compiler to target. It appears that VS2015 and VS2017 are ABI compatible, so theoretically, libs compiled with the 2015 toolset should be useable with VS2017 straightaway.

VS2017 has changed some things underneath in the toolchain, mostly to be able to support multiple instances of compiler toolchains installed side-by-side, and for this reason it might be worth porting apothecary/VS to the latest (VS2017) toolchain.

This is a work in progress. 

Building libraries on a windows system is far from seamless, mainly because there are multiple unix-style environments to choose from, but none seems complete. None seems to have all the tools needed to download, build, and install libraries through apothecary by itself.

# update cmake to 3.8.2 

MINGW64 installed with git for windows can start windows apps if they are discoverable through `PATH` - and as such it may use the latest version of cmake for windows, which may have been installed standalone. 

cmake needs to be > 3.8.2. to support templates for visual studio 2017. It should be possible to create templates for VS2015, and then run `vs-upgrade`, but that doesn't sound elegant. On the other side, MYSYS2 will only currently install cmake 3.6.2. through its `pacman`, so it's a bit of a dilemma. 

# first download recipes using msys2

As git for windows / MINGW64 won't include wget in its bundled unix-like commands, and most recipes depend on wget to download source, I suggest doing the download step in a MYSYS2 shell, and then do the build/install 

# update core:

	cd Documents/developer/of-vs2017/scripts/apothecary/apothecary/
	./apothecary -a 64 -t vs -d ../../../libs -v update core

# first build openssl, then curl, as one depends on the other

	./apothecary -a 64 -t vs -d ../../../libs -v update openssl
	./apothecary -a 64 -t vs -d ../../../libs -v update curl

# problems / questions :

Q: which windows unix-style shells to favour?
As a testing environment i'm using [MYSYS2](http://www.msys2.org/) as this is more or less what's running on the CI server, and the shell escapes and other subtleties can be tested this way.

# Progress

- [x] boost
- [x] curl
- [x] FreeImage
- [x] freetype
- [x] kiss (n/a)
- [x] libpng
- [x] libxml2
- [x] openssl
- [x] poco
- [x] svgtiny
- [x] tess2
- [x] uri
- [x] uriparser
- [x] assimp
- [x] cairo
  - [x] pixman
  - [x] pkg-config
  - [x] zlib
- [x] fmodex
- [x] glew
- [x] glfw
- [x] glm
- [x] json
- [x] opencv
- [x] portaudio
- [x] pugixml
- [x] rtAudio
- [x] utf8
- [x] videoInput

# Update (04 July 2017) Complete

Download libs as compressed build artifacts via Appveyor CI from here: https://ci.appveyor.com/project/arturoc/apothecary/build/2.0.306