### PR TITLE
fix to force xcode to build universal libusb

### DIFF
--- a/apothecary/formulas/libusb.sh
+++ b/apothecary/formulas/libusb.sh
@@ -50,7 +50,7 @@ function build() {
 
     if [ "$TYPE" == "osx" ] ; then
         cd Xcode
-        xcodebuild -configuration Release -target libusb -project libusb.xcodeproj/
+        xcodebuild ARCHS="i386 x86_64" ONLY_ACTIVE_ARCH=NO -configuration Release -target libusb -project libusb.xcodeproj/
 	fi
 
 }


### PR DESCRIPTION
This should force universal 64bit / 32bit libs for the libusb formula. 
Should fix the errors reported here: https://github.com/openframeworks/openFrameworks/pull/5711