### PR TITLE
split vs builds into bundles

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,28 @@ environment:
       VS_VER: 15
       ARCH: 64
       VS_NAME: 2017
+      BUNDLE: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x64
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 64
+      VS_NAME: 2017
+      BUNDLE: 2
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x64
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 64
+      VS_NAME: 2017
+      BUNDLE: 3
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x64
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 64
+      VS_NAME: 2017
+      BUNDLE: 4
   # VisualStudio 2017 32 bit Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x86
@@ -19,6 +41,28 @@ environment:
       VS_VER: 15
       ARCH: 32
       VS_NAME: 2017
+      BUNDLE: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x86
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 32
+      VS_NAME: 2017
+      BUNDLE: 2
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x86
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 32
+      VS_NAME: 2017
+      BUNDLE: 3
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x86
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 32
+      VS_NAME: 2017
+      BUNDLE: 4
   # MSYS2 Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       platform: x86
@@ -32,6 +76,28 @@ environment:
       VS_VER: 14
       ARCH: 32
       VS_NAME: 2015
+      BUNDLE: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x86
+      TARGET: vs
+      VS_VER: 14
+      ARCH: 32
+      VS_NAME: 2015
+      BUNDLE: 2
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x86
+      TARGET: vs
+      VS_VER: 14
+      ARCH: 32
+      VS_NAME: 2015
+      BUNDLE: 3
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x86
+      TARGET: vs
+      VS_VER: 14
+      ARCH: 32
+      VS_NAME: 2015
+      BUNDLE: 4
   #VisualStudio 2015 64 bit Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       platform: x64
@@ -39,6 +105,28 @@ environment:
       VS_VER: 14
       ARCH: 64
       VS_NAME: 2015
+      BUNDLE: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      TARGET: vs
+      VS_VER: 14
+      ARCH: 64
+      VS_NAME: 2015
+      BUNDLE: 2
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      TARGET: vs
+      VS_VER: 14
+      ARCH: 64
+      VS_NAME: 2015
+      BUNDLE: 3
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      TARGET: vs
+      VS_VER: 14
+      ARCH: 64
+      VS_NAME: 2015
+      BUNDLE: 4
 
 configuration: Debug
 shallow_clone: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,49 +6,49 @@ environment:
     CHERE_INVOKING: 1
   matrix:
   # VisualStudio 2017 64 bit Building
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x64
-      TARGET: vs
-      VS_VER: 15
-      ARCH: 64
-      VS_NAME: 2017
-      BUNDLE: 1
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x64
-      TARGET: vs
-      VS_VER: 15
-      ARCH: 64
-      VS_NAME: 2017
-      BUNDLE: 2
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x64
-      TARGET: vs
-      VS_VER: 15
-      ARCH: 64
-      VS_NAME: 2017
-      BUNDLE: 3
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x64
-      TARGET: vs
-      VS_VER: 15
-      ARCH: 64
-      VS_NAME: 2017
-      BUNDLE: 4
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    #   platform: x64
+    #   TARGET: vs
+    #   VS_VER: 15
+    #   ARCH: 64
+    #   VS_NAME: 2017
+    #   BUNDLE: 1
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    #   platform: x64
+    #   TARGET: vs
+    #   VS_VER: 15
+    #   ARCH: 64
+    #   VS_NAME: 2017
+    #   BUNDLE: 2
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    #   platform: x64
+    #   TARGET: vs
+    #   VS_VER: 15
+    #   ARCH: 64
+    #   VS_NAME: 2017
+    #   BUNDLE: 3
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    #   platform: x64
+    #   TARGET: vs
+    #   VS_VER: 15
+    #   ARCH: 64
+    #   VS_NAME: 2017
+    #   BUNDLE: 4
   # VisualStudio 2017 32 bit Building
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x86
-      TARGET: vs
-      VS_VER: 15
-      ARCH: 32
-      VS_NAME: 2017
-      BUNDLE: 1
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x86
-      TARGET: vs
-      VS_VER: 15
-      ARCH: 32
-      VS_NAME: 2017
-      BUNDLE: 2
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    #   platform: x86
+    #   TARGET: vs
+    #   VS_VER: 15
+    #   ARCH: 32
+    #   VS_NAME: 2017
+    #   BUNDLE: 1
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    #   platform: x86
+    #   TARGET: vs
+    #   VS_VER: 15
+    #   ARCH: 32
+    #   VS_NAME: 2017
+    #   BUNDLE: 2
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x86
       TARGET: vs
@@ -56,77 +56,77 @@ environment:
       ARCH: 32
       VS_NAME: 2017
       BUNDLE: 3
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x86
-      TARGET: vs
-      VS_VER: 15
-      ARCH: 32
-      VS_NAME: 2017
-      BUNDLE: 4
-  # MSYS2 Building
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x86
-      TARGET: msys2
-      ARCH: 32
-      VS_NAME: 
-  #VisualStudio 2015 32 bit Building
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x86
-      TARGET: vs
-      VS_VER: 14
-      ARCH: 32
-      VS_NAME: 2015
-      BUNDLE: 1
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x86
-      TARGET: vs
-      VS_VER: 14
-      ARCH: 32
-      VS_NAME: 2015
-      BUNDLE: 2
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x86
-      TARGET: vs
-      VS_VER: 14
-      ARCH: 32
-      VS_NAME: 2015
-      BUNDLE: 3
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x86
-      TARGET: vs
-      VS_VER: 14
-      ARCH: 32
-      VS_NAME: 2015
-      BUNDLE: 4
-  #VisualStudio 2015 64 bit Building
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x64
-      TARGET: vs
-      VS_VER: 14
-      ARCH: 64
-      VS_NAME: 2015
-      BUNDLE: 1
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x64
-      TARGET: vs
-      VS_VER: 14
-      ARCH: 64
-      VS_NAME: 2015
-      BUNDLE: 2
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x64
-      TARGET: vs
-      VS_VER: 14
-      ARCH: 64
-      VS_NAME: 2015
-      BUNDLE: 3
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      platform: x64
-      TARGET: vs
-      VS_VER: 14
-      ARCH: 64
-      VS_NAME: 2015
-      BUNDLE: 4
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  #     platform: x86
+  #     TARGET: vs
+  #     VS_VER: 15
+  #     ARCH: 32
+  #     VS_NAME: 2017
+  #     BUNDLE: 4
+  # # MSYS2 Building
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x86
+  #     TARGET: msys2
+  #     ARCH: 32
+  #     VS_NAME: 
+  # #VisualStudio 2015 32 bit Building
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x86
+  #     TARGET: vs
+  #     VS_VER: 14
+  #     ARCH: 32
+  #     VS_NAME: 2015
+  #     BUNDLE: 1
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x86
+  #     TARGET: vs
+  #     VS_VER: 14
+  #     ARCH: 32
+  #     VS_NAME: 2015
+  #     BUNDLE: 2
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x86
+  #     TARGET: vs
+  #     VS_VER: 14
+  #     ARCH: 32
+  #     VS_NAME: 2015
+  #     BUNDLE: 3
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x86
+  #     TARGET: vs
+  #     VS_VER: 14
+  #     ARCH: 32
+  #     VS_NAME: 2015
+  #     BUNDLE: 4
+  # #VisualStudio 2015 64 bit Building
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x64
+  #     TARGET: vs
+  #     VS_VER: 14
+  #     ARCH: 64
+  #     VS_NAME: 2015
+  #     BUNDLE: 1
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x64
+  #     TARGET: vs
+  #     VS_VER: 14
+  #     ARCH: 64
+  #     VS_NAME: 2015
+  #     BUNDLE: 2
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x64
+  #     TARGET: vs
+  #     VS_VER: 14
+  #     ARCH: 64
+  #     VS_NAME: 2015
+  #     BUNDLE: 3
+  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #     platform: x64
+  #     TARGET: vs
+  #     VS_VER: 14
+  #     ARCH: 64
+  #     VS_NAME: 2015
+  #     BUNDLE: 4
 
 configuration: Debug
 shallow_clone: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,49 +6,49 @@ environment:
     CHERE_INVOKING: 1
   matrix:
   # VisualStudio 2017 64 bit Building
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    #   platform: x64
-    #   TARGET: vs
-    #   VS_VER: 15
-    #   ARCH: 64
-    #   VS_NAME: 2017
-    #   BUNDLE: 1
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    #   platform: x64
-    #   TARGET: vs
-    #   VS_VER: 15
-    #   ARCH: 64
-    #   VS_NAME: 2017
-    #   BUNDLE: 2
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    #   platform: x64
-    #   TARGET: vs
-    #   VS_VER: 15
-    #   ARCH: 64
-    #   VS_NAME: 2017
-    #   BUNDLE: 3
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    #   platform: x64
-    #   TARGET: vs
-    #   VS_VER: 15
-    #   ARCH: 64
-    #   VS_NAME: 2017
-    #   BUNDLE: 4
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x64
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 64
+      VS_NAME: 2017
+      BUNDLE: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x64
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 64
+      VS_NAME: 2017
+      BUNDLE: 2
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x64
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 64
+      VS_NAME: 2017
+      BUNDLE: 3
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x64
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 64
+      VS_NAME: 2017
+      BUNDLE: 4
   # VisualStudio 2017 32 bit Building
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    #   platform: x86
-    #   TARGET: vs
-    #   VS_VER: 15
-    #   ARCH: 32
-    #   VS_NAME: 2017
-    #   BUNDLE: 1
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    #   platform: x86
-    #   TARGET: vs
-    #   VS_VER: 15
-    #   ARCH: 32
-    #   VS_NAME: 2017
-    #   BUNDLE: 2
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x86
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 32
+      VS_NAME: 2017
+      BUNDLE: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x86
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 32
+      VS_NAME: 2017
+      BUNDLE: 2
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x86
       TARGET: vs
@@ -56,77 +56,77 @@ environment:
       ARCH: 32
       VS_NAME: 2017
       BUNDLE: 3
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-  #     platform: x86
-  #     TARGET: vs
-  #     VS_VER: 15
-  #     ARCH: 32
-  #     VS_NAME: 2017
-  #     BUNDLE: 4
-  # # MSYS2 Building
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x86
-  #     TARGET: msys2
-  #     ARCH: 32
-  #     VS_NAME: 
-  # #VisualStudio 2015 32 bit Building
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x86
-  #     TARGET: vs
-  #     VS_VER: 14
-  #     ARCH: 32
-  #     VS_NAME: 2015
-  #     BUNDLE: 1
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x86
-  #     TARGET: vs
-  #     VS_VER: 14
-  #     ARCH: 32
-  #     VS_NAME: 2015
-  #     BUNDLE: 2
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x86
-  #     TARGET: vs
-  #     VS_VER: 14
-  #     ARCH: 32
-  #     VS_NAME: 2015
-  #     BUNDLE: 3
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x86
-  #     TARGET: vs
-  #     VS_VER: 14
-  #     ARCH: 32
-  #     VS_NAME: 2015
-  #     BUNDLE: 4
-  # #VisualStudio 2015 64 bit Building
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x64
-  #     TARGET: vs
-  #     VS_VER: 14
-  #     ARCH: 64
-  #     VS_NAME: 2015
-  #     BUNDLE: 1
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x64
-  #     TARGET: vs
-  #     VS_VER: 14
-  #     ARCH: 64
-  #     VS_NAME: 2015
-  #     BUNDLE: 2
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x64
-  #     TARGET: vs
-  #     VS_VER: 14
-  #     ARCH: 64
-  #     VS_NAME: 2015
-  #     BUNDLE: 3
-  #   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-  #     platform: x64
-  #     TARGET: vs
-  #     VS_VER: 14
-  #     ARCH: 64
-  #     VS_NAME: 2015
-  #     BUNDLE: 4
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x86
+      TARGET: vs
+      VS_VER: 15
+      ARCH: 32
+      VS_NAME: 2017
+      BUNDLE: 4
+  # MSYS2 Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x86
+      TARGET: msys2
+      ARCH: 32
+      VS_NAME: 
+  #VisualStudio 2015 32 bit Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x86
+      TARGET: vs
+      VS_VER: 14
+      ARCH: 32
+      VS_NAME: 2015
+      BUNDLE: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x86
+      TARGET: vs
+      VS_VER: 14
+      ARCH: 32
+      VS_NAME: 2015
+      BUNDLE: 2
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x86
+      TARGET: vs
+      VS_VER: 14
+      ARCH: 32
+      VS_NAME: 2015
+      BUNDLE: 3
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x86
+      TARGET: vs
+      VS_VER: 14
+      ARCH: 32
+      VS_NAME: 2015
+      BUNDLE: 4
+  #VisualStudio 2015 64 bit Building
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      TARGET: vs
+      VS_VER: 14
+      ARCH: 64
+      VS_NAME: 2015
+      BUNDLE: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      TARGET: vs
+      VS_VER: 14
+      ARCH: 64
+      VS_NAME: 2015
+      BUNDLE: 2
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      TARGET: vs
+      VS_VER: 14
+      ARCH: 64
+      VS_NAME: 2015
+      BUNDLE: 3
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      platform: x64
+      TARGET: vs
+      VS_VER: 14
+      ARCH: 64
+      VS_NAME: 2015
+      BUNDLE: 4
 
 configuration: Debug
 shallow_clone: true

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -305,18 +305,21 @@ if  type "ccache" > /dev/null; then
     echo $(ccache -s)
 fi
 
-if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]] || [[ ! -z ${APPVEYOR+x} && -z ${APPVEYOR_PULL_REQUEST_NUMBER+x} ]]; then
-    # exit here on PR's
-    echo "On Master Branch and not a PR";
-else
-    echo "This is a PR or not master branch, exiting build before compressing";
-    exit 0
-fi
+# if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]] || [[ ! -z ${APPVEYOR+x} && -z ${APPVEYOR_PULL_REQUEST_NUMBER+x} ]]; then
+#     # exit here on PR's
+#     echo "On Master Branch and not a PR";
+# else
+#     echo "This is a PR or not master branch, exiting build before compressing";
+#     exit 0
+# fi
 
 if [[ $TRAVIS_SECURE_ENV_VARS == "false" ]]; then
     echo "No secure vars set so exiting before compressing";
     exit 0
 fi
+
+echo "output folder: ${OUTPUT_FOLDER}"
+echo "ROOT folder: ${ROOT}"
 
 cd $OUTPUT_FOLDER
 echo "Compressing libraries from $OUTPUT_FOLDER"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -323,7 +323,7 @@ echo "Compressing libraries from $OUTPUT_FOLDER"
 LIBS=$(ls)
 
 if [ ! -z ${APPVEYOR+x} ]; then
-	TARBALL=openFrameworksLibs_${APPVEYOR_REPO_BRANCH}_${TARGET}${VS_NAME}_${ARCH}_${BUNDLE}.zip
+	TARBALL=${ROOT}/openFrameworksLibs_${APPVEYOR_REPO_BRANCH}_${TARGET}${VS_NAME}_${ARCH}_${BUNDLE}.zip
 	7z a $TARBALL $LIBS
 else
 	TARBALL=openFrameworksLibs_${TRAVIS_BRANCH}_$TARGET$OPT$ARCH$BUNDLE.tar.bz2

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -305,21 +305,18 @@ if  type "ccache" > /dev/null; then
     echo $(ccache -s)
 fi
 
-# if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]] || [[ ! -z ${APPVEYOR+x} && -z ${APPVEYOR_PULL_REQUEST_NUMBER+x} ]]; then
-#     # exit here on PR's
-#     echo "On Master Branch and not a PR";
-# else
-#     echo "This is a PR or not master branch, exiting build before compressing";
-#     exit 0
-# fi
+if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]] || [[ ! -z ${APPVEYOR+x} && -z ${APPVEYOR_PULL_REQUEST_NUMBER+x} ]]; then
+    # exit here on PR's
+    echo "On Master Branch and not a PR";
+else
+    echo "This is a PR or not master branch, exiting build before compressing";
+    exit 0
+fi
 
 if [[ $TRAVIS_SECURE_ENV_VARS == "false" ]]; then
     echo "No secure vars set so exiting before compressing";
     exit 0
 fi
-
-echo "output folder: ${OUTPUT_FOLDER}"
-echo "ROOT folder: ${ROOT}"
 
 cd $OUTPUT_FOLDER
 echo "Compressing libraries from $OUTPUT_FOLDER"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -59,7 +59,7 @@ FORMULAS=(
 )
 
 # Seperate in bundles on osx
-if [ "$TARGET" == "ios" ] || [ "$TARGET" == "tvos" ] || [ "$TARGET" == "osx" ]; then
+if [ "$TARGET" == "ios" ] || [ "$TARGET" == "tvos" ] || [ "$TARGET" == "osx" ] || [ "$TARGET" == "vs" ]; then
     if [ "$BUNDLE" == "1" ]; then
         FORMULAS=(
             # Dependencies for other formulas (cairo)
@@ -323,7 +323,7 @@ echo "Compressing libraries from $OUTPUT_FOLDER"
 LIBS=$(ls)
 
 if [ ! -z ${APPVEYOR+x} ]; then
-	TARBALL=openFrameworksLibs_${APPVEYOR_REPO_BRANCH}_${TARGET}${VS_NAME}_${ARCH}.zip
+	TARBALL=openFrameworksLibs_${APPVEYOR_REPO_BRANCH}_${TARGET}${VS_NAME}_${ARCH}_${BUNDLE}.zip
 	7z a $TARBALL $LIBS
 else
 	TARBALL=openFrameworksLibs_${TRAVIS_BRANCH}_$TARGET$OPT$ARCH$BUNDLE.tar.bz2


### PR DESCRIPTION
to keep compile times per build under the 1h maximum, we splits vs builds into bundles, similar to how this is done with os x bundles.