### PR TITLE
Fixes apothecary support for arm* hosts.

### DIFF
--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -1260,7 +1260,7 @@ fi
 
 CROSSCOMPILING=0
 if [ "$TYPE" == "linuxarmv6l" ] || [ "$TYPE" == "linuxarmv7l" ]; then
-    if [ "$(uname -m)" != "armv6" -a "$(uname -m)" != "armv7" ]; then
+    if [[ $(uname -m) != armv* ]]; then
         CROSSCOMPILING=1
         if [ -z $TOOLCHAIN_PREFIX ]; then
             export TOOLCHAIN_PREFIX=arm-linux-gnueabihf

--- a/scripts/linuxarmv6l/install.sh
+++ b/scripts/linuxarmv6l/install.sh
@@ -63,23 +63,26 @@ relativeSoftLinks(){
     done
 }
 
+if [[ $(uname -m) != armv* ]]; then
 
-ROOT=$( cd "$(dirname "$0")" ; pwd -P )
-echo $ROOT
-cd $ROOT
-installPackages
-createRaspbianImg
-downloadToolchain
-downloadFirmware
+	ROOT=$( cd "$(dirname "$0")" ; pwd -P )
+	echo $ROOT
+	cd $ROOT
+	installPackages
+	createRaspbianImg
+	downloadToolchain
+	downloadFirmware
 
-cd $ROOT/raspbian/usr/lib
-relativeSoftLinks
-cd $ROOT/raspbian/usr/lib/arm-linux-gnueabihf
-relativeSoftLinks
-cd $ROOT/raspbian/usr/lib/gcc/arm-linux-gnueabihf/4.9
+	cd $ROOT/raspbian/usr/lib
+	relativeSoftLinks
+	cd $ROOT/raspbian/usr/lib/arm-linux-gnueabihf
+	relativeSoftLinks
+	cd $ROOT/raspbian/usr/lib/gcc/arm-linux-gnueabihf/4.9
 
-cd $ROOT/rpi_toolchain/arm-linux-gnueabihf/lib
-#sed -i "s|/home/arturo/Code/openFrameworks/apothecary/scripts/linuxarm/rpi_toolchain/arm-linux-gnueabihf/lib|$ROOT/rpi_toolchain/arm-linux-gnueabihf/lib|g" libc.so
-for f in *.so; do
-    sed -i "s|/home/arturo/Code/openFrameworks/apothecary/scripts/linuxarm/rpi_toolchain/arm-linux-gnueabihf/lib|$ROOT/rpi_toolchain/arm-linux-gnueabihf/lib|g" $f
-done
+	cd $ROOT/rpi_toolchain/arm-linux-gnueabihf/lib
+	#sed -i "s|/home/arturo/Code/openFrameworks/apothecary/scripts/linuxarm/rpi_toolchain/arm-linux-gnueabihf/lib|$ROOT/rpi_toolchain/arm-linux-gnueabihf/lib|g" libc.so
+	for f in *.so; do
+	    sed -i "s|/home/arturo/Code/openFrameworks/apothecary/scripts/linuxarm/rpi_toolchain/arm-linux-gnueabihf/lib|$ROOT/rpi_toolchain/arm-linux-gnueabihf/lib|g" $f
+	done
+	
+fi

--- a/scripts/linuxarmv7l/install.sh
+++ b/scripts/linuxarmv7l/install.sh
@@ -94,17 +94,21 @@ installJunest(){
 EOF
 }
 
-ROOT=$( cd "$(dirname "$0")" ; pwd -P )
-echo $ROOT
-cd $ROOT
-installJunest
-createArchImg
-downloadToolchain
-downloadFirmware
+if [[ $(uname -m) != armv* ]]; then
 
-cd $HOME/archlinux/usr/lib
-relativeSoftLinks "../.." "..\/.."
-#cd $ROOT/archlinux/usr/lib/arm-unknown-linux-gnueabihf
-#relativeSoftLinks  "../../.." "..\/..\/.."
-#cd $ROOT/raspbian/usr/lib/gcc/arm-unknown-linux-gnueabihf/5.3
-#relativeSoftLinks  "../../../.." "..\/..\/..\/.."
+	ROOT=$( cd "$(dirname "$0")" ; pwd -P )
+	echo $ROOT
+	cd $ROOT
+	installJunest
+	createArchImg
+	downloadToolchain
+	downloadFirmware
+
+	cd $HOME/archlinux/usr/lib
+	relativeSoftLinks "../.." "..\/.."
+	#cd $ROOT/archlinux/usr/lib/arm-unknown-linux-gnueabihf
+	#relativeSoftLinks  "../../.." "..\/..\/.."
+	#cd $ROOT/raspbian/usr/lib/gcc/arm-unknown-linux-gnueabihf/5.3
+	#relativeSoftLinks  "../../../.." "..\/..\/..\/.."
+	
+fi


### PR DESCRIPTION
Modern raspberry pi, etc identify as `armv7l`.  This avoids cross-compiler installation on arm* hosts and allows apothecary to be run from arm* hosts directly, specifically useful for addons.

Fixes #99 
Part of a fix for https://github.com/bakercp/ofxDlib/issues/26

cc @neilmendoza