### PR TITLE
fixing building on osx without the ios libs installed.

### DIFF
--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -48,7 +48,7 @@ BUILD_DEPENDENCIES=1
 HOST_OS= # compile os ("osx", "windows", "linux")
 TYPE= # library build type ("osx", "ios", "vs", etc)
 ARCH=32 # library build arch, 32 or 64 bit (not used for some build types)
-
+ARCH_FLAG=i386
 # full path to this script's dir
 APOTHECARY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -88,12 +88,13 @@ if [ "$(${APOTHECARY_DIR}/ostype.sh)" == "osx" ]; then
     OSX_SDK_VER=10.11
     OSX_MIN_SDK_VER=10.9
 
-    # used when building for ios, the sdks you have installed are found in:
-    # $XCODE_DEV_ROOT/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator#.#.sdk
-    IOS_LATEST_SDK="xcrun -sdk iphoneos --show-sdk-version" # stupid hack to keep my syntax highlighting from breaking :P
-    IOS_SDK_VER=9.1
-    IOS_MIN_SDK_VER=7.0
-
+	if [ "$TYPE" == "ios" ]; then
+		# used when building for ios, the sdks you have installed are found in:
+		# $XCODE_DEV_ROOT/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator#.#.sdk
+		IOS_LATEST_SDK="xcrun -sdk iphoneos --show-sdk-version" # stupid hack to keep my syntax highlighting from breaking :P
+		IOS_SDK_VER=9.1
+		IOS_MIN_SDK_VER=7.0
+	fi
 
 fi
 
@@ -1190,7 +1191,9 @@ echoVerbose "Valid build types: ${VALID_TYPES[*]}"
 if [ "$HOST_OS" == "osx" ] ; then
 	XCODE_DEV_ROOT=$($XS) # Sets to path from Xcode Path
 	OSX_SDK_VER=$($OSX_LATEST_SDK) # sets to latest OSX SDK
-	IOS_SDK_VER=$($IOS_LATEST_SDK) # sets to latest iOS SDK
+	if [ "$TYPE" == "ios" ]; then
+		IOS_SDK_VER=$($IOS_LATEST_SDK) # sets to latest iOS SDK
+	fi
 fi
 
 # check if we have a valid build type

--- a/apothecary/formulas/opencv/opencv.sh
+++ b/apothecary/formulas/opencv/opencv.sh
@@ -38,6 +38,17 @@ function prepare() {
 
 # executed inside the lib src dir
 function build() {
+
+  if [ "$ARCH" == "32" ] ; then
+      ARCH_FLAG=i386
+  fi
+
+  if [ "$ARCH" == "64" ] ; then
+      ARCH_FLAG=x86_64
+  fi
+
+  echo $ARCH_FLAG
+
   rm -f CMakeCache.txt
 
   LIB_FOLDER="$BUILD_DIR/opencv/build/$TYPE/"
@@ -53,8 +64,8 @@ function build() {
     cmake .. -DCMAKE_INSTALL_PREFIX=$LIB_FOLDER \
       -DCMAKE_OSX_DEPLOYMENT_TARGET=10.7 \
       -DENABLE_FAST_MATH=OFF \
-      -DCMAKE_CXX_FLAGS="-fvisibility-inlines-hidden -stdlib=libc++ -std=c++11 -O3 -fPIC -arch i386 -arch x86_64 -mmacosx-version-min=${OSX_MIN_SDK_VER}" \
-      -DCMAKE_C_FLAGS="-fvisibility-inlines-hidden -stdlib=libc++ -O3 -fPIC -arch i386 -arch x86_64 -mmacosx-version-min=${OSX_MIN_SDK_VER}" \
+      -DCMAKE_CXX_FLAGS="-fvisibility-inlines-hidden -stdlib=libc++ -std=c++11 -O3 -fPIC -arch ${ARCH_FLAG}  -mmacosx-version-min=${OSX_MIN_SDK_VER}" \
+      -DCMAKE_C_FLAGS="-fvisibility-inlines-hidden -stdlib=libc++ -O3 -fPIC -arch ${ARCH_FLAG} -mmacosx-version-min=${OSX_MIN_SDK_VER}" \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=OFF \
       -DBUILD_DOCS=OFF \


### PR DESCRIPTION
Fixing building on osx without the ios libs installed. 
Fixing opencv build to split 32/64 builds for osx installs without 32bit libs