### PR TITLE
longshot but hopefully fixes the emscripten issue

### DIFF
--- a/apothecary/formulas/opencv/opencv.sh
+++ b/apothecary/formulas/opencv/opencv.sh
@@ -464,6 +464,8 @@ function build() {
       echo "emscripten is not set.  sourcing emsdk_env.sh"
       source ~/emscripten-sdk/emsdk_env.sh
     fi
+    
+    export USE_PTHREADS=0
 
     cd ${BUILD_DIR}/${1}
     mkdir -p build_${TYPE}

--- a/apothecary/formulas/opencv/opencv.sh
+++ b/apothecary/formulas/opencv/opencv.sh
@@ -464,8 +464,6 @@ function build() {
       echo "emscripten is not set.  sourcing emsdk_env.sh"
       source ~/emscripten-sdk/emsdk_env.sh
     fi
-    
-    export USE_PTHREADS=0
 
     cd ${BUILD_DIR}/${1}
     mkdir -p build_${TYPE}
@@ -476,8 +474,8 @@ function build() {
       -DCPU_BASELINE='' \
       -DCPU_DISPATCH='' \
       -DCV_TRACE=OFF \
-      -DCMAKE_C_FLAGS=-I${EMSCRIPTEN}/system/lib/libcxxabi/include/ \
-      -DCMAKE_CXX_FLAGS=-I${EMSCRIPTEN}/system/lib/libcxxabi/include/ \
+      -DCMAKE_C_FLAGS=-I${EMSCRIPTEN}/system/lib/libcxxabi/include/ -s USE_PTHREADS=0  \
+      -DCMAKE_CXX_FLAGS=-I${EMSCRIPTEN}/system/lib/libcxxabi/include/ -s USE_PTHREADS=0  \
       -DBUILD_SHARED_LIBS=OFF \
       -DBUILD_DOCS=OFF \
       -DBUILD_EXAMPLES=OFF \

--- a/apothecary/formulas/opencv/opencv.sh
+++ b/apothecary/formulas/opencv/opencv.sh
@@ -474,8 +474,8 @@ function build() {
       -DCPU_BASELINE='' \
       -DCPU_DISPATCH='' \
       -DCV_TRACE=OFF \
-      -DCMAKE_C_FLAGS=-I${EMSCRIPTEN}/system/lib/libcxxabi/include/ -s USE_PTHREADS=0  \
-      -DCMAKE_CXX_FLAGS=-I${EMSCRIPTEN}/system/lib/libcxxabi/include/ -s USE_PTHREADS=0  \
+      -DCMAKE_C_FLAGS=-I${EMSCRIPTEN}/system/lib/libcxxabi/include/ USE_PTHREADS=0  \
+      -DCMAKE_CXX_FLAGS=-I${EMSCRIPTEN}/system/lib/libcxxabi/include/ USE_PTHREADS=0  \
       -DBUILD_SHARED_LIBS=OFF \
       -DBUILD_DOCS=OFF \
       -DBUILD_EXAMPLES=OFF \

--- a/apothecary/formulas/opencv/opencv.sh
+++ b/apothecary/formulas/opencv/opencv.sh
@@ -474,8 +474,8 @@ function build() {
       -DCPU_BASELINE='' \
       -DCPU_DISPATCH='' \
       -DCV_TRACE=OFF \
-      -DCMAKE_C_FLAGS=-I${EMSCRIPTEN}/system/lib/libcxxabi/include/ USE_PTHREADS=0  \
-      -DCMAKE_CXX_FLAGS=-I${EMSCRIPTEN}/system/lib/libcxxabi/include/ USE_PTHREADS=0  \
+      -DCMAKE_C_FLAGS="-s USE_PTHREADS=0 -I${EMSCRIPTEN}/system/lib/libcxxabi/include/" \
+      -DCMAKE_CXX_FLAGS="-s USE_PTHREADS=0 -I${EMSCRIPTEN}/system/lib/libcxxabi/include/" \
       -DBUILD_SHARED_LIBS=OFF \
       -DBUILD_DOCS=OFF \
       -DBUILD_EXAMPLES=OFF \


### PR DESCRIPTION
The issue seems to be tied to emscripten enabling pthreads by default in newer releases. 
We have pthreads disabled ( DWITH_PTHREADS_PF=OFF ) in our apothecary cmake flags but I think USE_PTHREADS=0 needs to be explicity set before building. 

This thread is helpful: 
https://github.com/opencv/opencv/issues/14691#issuecomment-509495464 

Also see this script which sets both:
https://github.com/opencv/opencv/blob/master/platforms/js/build_js.py#L178 

🤞