### PR TITLE
[change] shift arg error with bash on osx

### DIFF
--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -324,8 +324,7 @@ while getopts t:a:b:d:s:j:hgvxfp opt ; do
 			echo "$HELP" ; exit 0 ;;
 	esac
 done
-shift $(expr $OPTIND - 1)
-
+shift $(( $OPTIND - 1))
 
 # used when building for vs - set to 15 if not set explicitly
 if [ "$TYPE" = "vs" ]; then


### PR DESCRIPTION
Hi,
was getting this error as I was working the other one,
```./apothecary: line 328: shift: too many arguments```
which is probably because $OPTIND defaults to 1 without an additional argument.
Same thing can be reproduced by running a command line `apothecary update core`, making shift = 0 or error.

This takes care of that 