### PR TITLE
removes the patch that hangs vs build. closes #145

### DIFF
--- a/apothecary/formulas/openssl/openssl.sh
+++ b/apothecary/formulas/openssl/openssl.sh
@@ -43,11 +43,7 @@ function download() {
 
 # prepare the build environment, executed inside the lib src dir
 function prepare() {
-	if  [ "$TYPE" == "vs" ] ; then
-		if patch -p1 -u -N --dry-run --silent < $FORMULA_DIR/winOpenSSL.patch 2>/dev/null ; then
-			patch -p1 -u < $FORMULA_DIR/winOpenSSL.patch
-		fi
-	elif [ "$TYPE" == "tvos" ]; then
+	if [ "$TYPE" == "tvos" ]; then
 		cp $FORMULA_DIR/20-ios-tvos-cross.conf Configurations/
 	fi
 }


### PR DESCRIPTION
closes #145

should be good to merge. 
there are loads of AppVeyor errors at the moment which aren't related but last time it was tested this change just fixed the hanging prompt for patching a file which doesn't exist. 
