### PR TITLE
use http to retrieve libxml2 sources

### DIFF
--- a/apothecary/formulas/libxml2/libxml2.sh
+++ b/apothecary/formulas/libxml2/libxml2.sh
@@ -14,7 +14,7 @@ VER=2.9.4
 
 # download the source code and unpack it into LIB_NAME
 function download() {
-    wget -nv ftp://xmlsoft.org/libxml2/libxml2-${VER}.tar.gz
+    wget -v http://xmlsoft.org/sources/libxml2-${VER}.tar.gz
     tar xzf libxml2-${VER}.tar.gz
     mv libxml2-${VER} libxml2
     rm libxml2-${VER}.tar.gz


### PR DESCRIPTION
CI often fails because of not getting libxml2 tarball from ftp.
Switching to http may improve the situation.