### PR TITLE
removed ldap dependency on private LDAP.framework. closes #156

### DIFF
--- a/apothecary/formulas/curl/curl.sh
+++ b/apothecary/formulas/curl/curl.sh
@@ -95,6 +95,8 @@ function build() {
             --prefix=$BUILD_DIR/curl/build/osx/x86 \
             --enable-static \
             --disable-shared \
+            --disable-ldap \
+            --disable-ldaps \
             --host=x86-apple-darwin
         make clean
 	    make -j${PARALLEL_MAKE}
@@ -107,6 +109,8 @@ function build() {
             --prefix=$BUILD_DIR/curl/build/osx/x64 \
             --enable-static \
             --disable-shared \
+            --disable-ldap \
+            --disable-ldaps \
             --host=x86_64-apple-darwin
         make clean
 	    make -j${PARALLEL_MAKE}


### PR DESCRIPTION
closes #156 

Tested with the imageLoaderWebExample no linker errors without the LDAP.framework. 
Once this is merged we'll need to do a PR to modify [this line](https://github.com/openframeworks/openFrameworks/blob/patch-release/libs/openFrameworksCompiled/project/osx/CoreOF.xcconfig#L57) to remove LDAP 

