### PR TITLE
Curl macos fix legacy

### DIFF
--- a/scripts/calculate_formulas.sh
+++ b/scripts/calculate_formulas.sh
@@ -77,8 +77,8 @@ if [ "$TARGET" == "ios" ] || [ "$TARGET" == "tvos" ] || [ "$TARGET" == "osx" ] |
     elif [ "$BUNDLE" == "2" ]; then
         FORMULAS=(
             "openssl"
-            "poco"
             "curl"
+            "poco"
         )
     elif [ "$BUNDLE" == "3" ]; then
         FORMULAS=(

--- a/scripts/calculate_formulas.sh
+++ b/scripts/calculate_formulas.sh
@@ -77,8 +77,8 @@ if [ "$TARGET" == "ios" ] || [ "$TARGET" == "tvos" ] || [ "$TARGET" == "osx" ] |
     elif [ "$BUNDLE" == "2" ]; then
         FORMULAS=(
             "openssl"
-            "curl"
             "poco"
+            "curl"
         )
     elif [ "$BUNDLE" == "3" ]; then
         FORMULAS=(


### PR DESCRIPTION
This fixes #176 and seems like a good solution as we transition to 10.15 / 10.11 and keep backwards compatible support. 