### PR TITLE
bugfix for min osx sdk being set incorrectly

### DIFF
--- a/apothecary/formulas/glfw.sh
+++ b/apothecary/formulas/glfw.sh
@@ -64,7 +64,8 @@ function build() {
 					-DGLFW_BUILD_EXAMPLES=OFF \
 					-DBUILD_SHARED_LIBS=OFF \
 					-DCMAKE_BUILD_TYPE=Release \
-					-DCMAKE_C_FLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=${OSX_MIN_SDK_VER}" \
+                    -DCMAKE_OSX_DEPLOYMENT_TARGET=${OSX_MIN_SDK_VER} \
+                    -DCMAKE_C_FLAGS="-arch arm64 -arch x86_64" \
 					$EXTRA_CONFIG
 		else
 			cmake .. -DGLFW_BUILD_DOCS=OFF \


### PR DESCRIPTION
cmake uses DCMAKE_OSX_DEPLOYMENT_TARGET to set the min sdk for osx.
we weren't setting that so it was being set twice causing the CI builds to target 10.15 instead of OSX_MIN_SDK_VER

this should be the last fix needed to get macOS libs working for both older and newer mac platforms. 