### PR TITLE
Explicit linux gcc4

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -191,7 +191,11 @@ fi
 
 if [ "$TARGET" == "linux" ]; then
     TARGET="linux64"
-    if [ "$OPT" == "gcc5" ]; then
+    if [ "$OPT" == "gcc4" ]; then
+        export CC="gcc-4"
+        export CXX="g++-4 -std=c++11"
+        export COMPILER="g++4 -std=c++11"
+    elif [ "$OPT" == "gcc5" ]; then
         export CC="gcc-5"
         export CXX="g++-5 -std=c++11"
         export COMPILER="g++5 -std=c++11"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -192,9 +192,9 @@ fi
 if [ "$TARGET" == "linux" ]; then
     TARGET="linux64"
     if [ "$OPT" == "gcc4" ]; then
-        export CC="gcc-4"
-        export CXX="g++-4 -std=c++11"
-        export COMPILER="g++4 -std=c++11"
+        export CC="gcc"
+        export CXX="g++ -std=c++11"
+        export COMPILER="g++ -std=c++11"
     elif [ "$OPT" == "gcc5" ]; then
         export CC="gcc-5"
         export CXX="g++-5 -std=c++11"

--- a/scripts/linux/install.sh
+++ b/scripts/linux/install.sh
@@ -45,8 +45,10 @@ echoDots(){
 
 if [ "$OPT" == "gcc4" ]; then
     sudo add-apt-repository -y ppa:dns/gnu
+    sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     sudo apt-get update -q
     sudo apt-get install -y gperf coreutils realpath libxrandr-dev libxinerama-dev libx11-dev libxcursor-dev libxi-dev
+    sudo apt-get install gcc-4.9 g++-4.9
 elif [ "$OPT" == "gcc5" ]; then
     sudo add-apt-repository -y ppa:dns/gnu
     sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
I think this is why both PG and nightly is failing. With the switch from travis.yml the compiler default wasn't gcc-4.9 for the gcc4 option. So Poco and other libs were being linked with newer gcc.