### PR TITLE
fix emscripten to use offical docker and move from deprecated image

### DIFF
--- a/.github/workflows/build-emscripten.yml
+++ b/.github/workflows/build-emscripten.yml
@@ -16,7 +16,7 @@ jobs:
       steps:
       - uses: actions/checkout@v2
       - name: Docker Step
-        run:  "docker run -di --name emscripten -v $PWD:/src emscripten/emsdk:2.0.0 bash"
+        run:  "docker run -di --name emscripten -v $PWD:/src emscripten/emsdk:1.40.1 bash"
       - name: Scripts Calc Formula
         run: ./scripts/calculate_formulas.sh
       - name: Scripts Install

--- a/.github/workflows/build-emscripten.yml
+++ b/.github/workflows/build-emscripten.yml
@@ -16,7 +16,7 @@ jobs:
       steps:
       - uses: actions/checkout@v2
       - name: Docker Step
-        run:  "docker run -di --name emscripten -v $PWD:/src emscripten/emsdk:1.40.1 bash"
+        run:  "docker run -di --name emscripten -v $PWD:/src emscripten/emsdk:latest bash"
       - name: Scripts Calc Formula
         run: ./scripts/calculate_formulas.sh
       - name: Scripts Install

--- a/.github/workflows/build-emscripten.yml
+++ b/.github/workflows/build-emscripten.yml
@@ -16,7 +16,7 @@ jobs:
       steps:
       - uses: actions/checkout@v2
       - name: Docker Step
-        run:  "docker run -di --name emscripten -v $PWD:/src emscripten/emsdk:latest bash"
+        run:  "docker run -di --name emscripten -v $PWD:/src emscripten/emsdk:2.0.0 bash"
       - name: Scripts Calc Formula
         run: ./scripts/calculate_formulas.sh
       - name: Scripts Install

--- a/.github/workflows/build-emscripten.yml
+++ b/.github/workflows/build-emscripten.yml
@@ -16,7 +16,7 @@ jobs:
       steps:
       - uses: actions/checkout@v2
       - name: Docker Step
-        run:  "docker run -di --name emscripten -v $PWD:/src trzeci/emscripten:sdk-incoming-64bit bash"
+        run:  "docker run -di --name emscripten -v $PWD:/src emscripten/emsdk:latest bash"
       - name: Scripts Calc Formula
         run: ./scripts/calculate_formulas.sh
       - name: Scripts Install

--- a/apothecary/formulas/opencv/opencv.sh
+++ b/apothecary/formulas/opencv/opencv.sh
@@ -461,10 +461,7 @@ function build() {
     make install
 
   elif [ "$TYPE" == "emscripten" ]; then
-    if [ -z "${EMSCRIPTEN+x}" ]; then
-      echo "emscripten is not set.  sourcing emsdk_env.sh"
-      source /emsdk/emsdk_env.sh
-    fi
+    source /emsdk/emsdk_env.sh
 
     cd ${BUILD_DIR}/${1}
     mkdir -p build_${TYPE}
@@ -475,8 +472,8 @@ function build() {
       -DCPU_BASELINE='' \
       -DCPU_DISPATCH='' \
       -DCV_TRACE=OFF \
-      -DCMAKE_C_FLAGS="-s USE_PTHREADS=0 -I${EMSCRIPTEN}/system/lib/libcxxabi/include/" \
-      -DCMAKE_CXX_FLAGS="-s USE_PTHREADS=0 -I${EMSCRIPTEN}/system/lib/libcxxabi/include/" \
+      -DCMAKE_C_FLAGS="-s USE_PTHREADS=0 -I/emsdk/upstream/emscripten/system/lib/libcxxabi/include/" \
+      -DCMAKE_CXX_FLAGS="-s USE_PTHREADS=0 -I/emsdk/upstream/emscripten/system/lib/libcxxabi/include/" \
       -DBUILD_SHARED_LIBS=OFF \
       -DBUILD_DOCS=OFF \
       -DBUILD_EXAMPLES=OFF \

--- a/apothecary/formulas/opencv/opencv.sh
+++ b/apothecary/formulas/opencv/opencv.sh
@@ -464,8 +464,16 @@ function build() {
     source /emsdk/emsdk_env.sh
 
     cd ${BUILD_DIR}/${1}
+    
+    # fix a bug with newer emscripten not recognizing index and string error because python files opened in binary
+    # these can be removed when we move to latest opencv 
+    sed -i "s|element(index|element(emscripten::index|" modules/js/src/core_bindings.cpp
+    sed -i "s|open(opencvjs, 'r+b')|open(opencvjs, 'r+')|" modules/js/src/make_umd.py
+    sed -i "s|open(cvjs, 'w+b')|open(cvjs, 'w+')|" modules/js/src/make_umd.py
+
     mkdir -p build_${TYPE}
     cd build_${TYPE}
+    
     emcmake cmake .. -DCMAKE_INSTALL_PREFIX="${BUILD_DIR}/${1}/build_$TYPE/install" \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_opencv_js=ON \

--- a/apothecary/formulas/opencv/opencv.sh
+++ b/apothecary/formulas/opencv/opencv.sh
@@ -463,7 +463,7 @@ function build() {
   elif [ "$TYPE" == "emscripten" ]; then
     if [ -z "${EMSCRIPTEN+x}" ]; then
       echo "emscripten is not set.  sourcing emsdk_env.sh"
-      source ~/emscripten-sdk/emsdk_env.sh
+      source /emsdk/emsdk_env.sh
     fi
 
     cd ${BUILD_DIR}/${1}


### PR DESCRIPTION
sdk-incoming-64bit isn't supported anymore so emscripten now fails to link when using the nightly builds locally. 
this switches the docker image to the official one ( the other one is now deprecated ) 