### PR TITLE
glfw switch to 3.3 stable

### DIFF
--- a/apothecary/formulas/glfw.sh
+++ b/apothecary/formulas/glfw.sh
@@ -9,10 +9,10 @@
 FORMULA_TYPES=( "osx" "vs" )
 
 # define the version by branch  
-VER=2018-cmake-fix
+VER=3.3-stable
 
 # tools for git use
-GIT_URL=https://github.com/ofTheo/glfw.git
+GIT_URL=https://github.com/glfw/glfw/
 GIT_BRANCH=$VER
 
 # download the source code and unpack it into LIB_NAME


### PR DESCRIPTION
Switches glfw to their stable 3.3.3 version. 
( we were on 3.3.0 before ) 

Fixes weird permissions errors ( due to Big Sur building 3.3.0 ), that breaks drag and drop functionality on macOS. 
