### PR TITLE
fix fmod formula to set correct loader path for fmod

### DIFF
--- a/apothecary/formulas/fmod.sh
+++ b/apothecary/formulas/fmod.sh
@@ -41,7 +41,7 @@ function build() {
 
 	if [ "$TYPE" == "osx" ]; then
 		cd lib/osx
-		install_name_tool -id "@rpath/libfmod.dylib" libfmod.dylib
+		install_name_tool -id @executable_path/../Frameworks/libfmod.dylib libfmod.dylib
 		cd ../
 	fi
 

--- a/apothecary/formulas/kiss/kiss.sh
+++ b/apothecary/formulas/kiss/kiss.sh
@@ -9,18 +9,16 @@ FORMULA_TYPES=( "linux" "linux64" "linuxarmv6l" "linuxarmv7l" "msys2")
 
 # define the version
 VER=130
-VER_UNDERSCORE=1_3_0
 
 # tools for git use
-GIT_URL=
+GIT_URL=https://github.com/mborgerding/kissfft.git
 GIT_TAG=v$VER
 
 # download the source code and unpack it into LIB_NAME
 function download() {
-	wget -nv https://downloads.sourceforge.net/project/kissfft/kissfft/v$VER_UNDERSCORE/kiss_fft$VER.tar.gz
-	tar -xf kiss_fft$VER.tar.gz
-	mv kiss_fft$VER kiss
-	rm kiss_fft$VER.tar.gz
+    echo "Running: git clone --branch ${GIT_TAG} ${GIT_URL}"
+    git clone --branch ${GIT_TAG} ${GIT_URL}
+    mv  kissfft kiss
 }
 
 # prepare the build environment, executed inside the lib src dir

--- a/apothecary/formulas/kiss/kiss.sh
+++ b/apothecary/formulas/kiss/kiss.sh
@@ -17,7 +17,7 @@ GIT_TAG=v$VER
 
 # download the source code and unpack it into LIB_NAME
 function download() {
-	wget -nv http://downloads.sourceforge.net/project/kissfft/kissfft/v$VER_UNDERSCORE/kiss_fft$VER.tar.gz
+	wget -nv https://downloads.sourceforge.net/project/kissfft/kissfft/v$VER_UNDERSCORE/kiss_fft$VER.tar.gz
 	tar -xf kiss_fft$VER.tar.gz
 	mv kiss_fft$VER kiss
 	rm kiss_fft$VER.tar.gz


### PR DESCRIPTION
need to change the install_name_tool command to look in Frameworks. 
avoids the need for setting in the Xcode project. 

related PR:
https://github.com/openframeworks/openFrameworks/pull/6679

