### PR TITLE
Fix opencv arm64

### DIFF
--- a/apothecary/formulas/opencv/opencv.sh
+++ b/apothecary/formulas/opencv/opencv.sh
@@ -52,9 +52,10 @@ function build() {
     set +e
     cmake .. -DCMAKE_INSTALL_PREFIX=$LIB_FOLDER \
       -DCMAKE_OSX_DEPLOYMENT_TARGET=${OSX_MIN_SDK_VER} \
+      -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
       -DENABLE_FAST_MATH=OFF \
-      -DCMAKE_CXX_FLAGS="-fvisibility-inlines-hidden -stdlib=libc++ -std=c++11 -O3 -fPIC -arch arm64 -arch x86_64 -Wno-implicit-function-declaration -mmacosx-version-min=${OSX_MIN_SDK_VER}" \
-      -DCMAKE_C_FLAGS="-fvisibility-inlines-hidden -stdlib=libc++ -O3 -fPIC -arch arm64 -arch x86_64 -Wno-implicit-function-declaration -mmacosx-version-min=${OSX_MIN_SDK_VER}" \
+      -DCMAKE_CXX_FLAGS="-fvisibility-inlines-hidden -stdlib=libc++ -std=c++11 -O3 -fPIC -Wno-implicit-function-declaration -mmacosx-version-min=${OSX_MIN_SDK_VER}" \
+      -DCMAKE_C_FLAGS="-fvisibility-inlines-hidden -stdlib=libc++ -O3 -fPIC -Wno-implicit-function-declaration -mmacosx-version-min=${OSX_MIN_SDK_VER}" \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=OFF \
       -DBUILD_DOCS=OFF \

--- a/apothecary/formulas/opencv/opencv.sh
+++ b/apothecary/formulas/opencv/opencv.sh
@@ -128,10 +128,11 @@ function build() {
     echo "Make install Successful"
 
     echo "--------------------"
-    echo "Joining all libs in one"
-    outputlist="$LIB_FOLDER/lib/lib*.a $LIB_FOLDER/lib/opencv4/3rdparty/*.a"
-    libtool -static $outputlist -o "$LIB_FOLDER/lib/opencv.a" 2>&1 | tee -a ${LOG}
-    echo "Joining all libs in one Successful"
+    # we don't do this anymore as it results in duplicate symbol issues
+    # echo "Joining all libs in one"
+    # outputlist="$LIB_FOLDER/lib/lib*.a $LIB_FOLDER/lib/opencv4/3rdparty/*.a"
+    # libtool -static $outputlist -o "$LIB_FOLDER/lib/opencv.a" 2>&1 | tee -a ${LOG}
+    # echo "Joining all libs in one Successful"
 
   elif [ "$TYPE" == "vs" ] ; then
     unset TMP
@@ -588,7 +589,8 @@ function copy() {
     cp -R modules/*/include/opencv2/* $1/include/opencv2/
 
     # copy lib
-    cp -R $LIB_FOLDER/lib/opencv.a $1/lib/$TYPE/
+    cp -R $LIB_FOLDER/lib/lib*.a $1/lib/$TYPE/
+    cp -R $LIB_FOLDER/lib/opencv4/3rdparty/*.a $1/lib/$TYPE/
 
   elif [ "$TYPE" == "vs" ] ; then
     if [ $ARCH == 32 ] ; then


### PR DESCRIPTION
there are some linker errors currently for opencv running on arm64 / M1 machines. 
See: https://forum.openframeworks.cc/t/of-fullscreen-causing-crash-with-validaterenderpassdescriptor/37220/3

looking at the build logs I see a lot of linker warnings when using libtool that duplicate symbols exist because we are linking all the opencv libs into a single one. 

I think/hope changing the formula to use the actual libs produced by opencv instead of a single libtool one will fix the issue. 
