### PR TITLE
revert glfw to version for 0.11.0. 

### DIFF
--- a/apothecary/formulas/glfw.sh
+++ b/apothecary/formulas/glfw.sh
@@ -9,10 +9,10 @@
 FORMULA_TYPES=( "osx" "vs" )
 
 # define the version by branch  
-VER=3.3-stable
+VER=2018-cmake-fix
 
 # tools for git use
-GIT_URL=https://github.com/glfw/glfw/
+GIT_URL=https://github.com/ofTheo/glfw/
 GIT_BRANCH=$VER
 
 # download the source code and unpack it into LIB_NAME


### PR DESCRIPTION
Current GLFW master causes a memory leak on draw with arm64 on Big Sur. Tried tracking it down, but there are tons of changes. Will try and fix for 0.12.0 but reverting to 0.11.0 glfw version for now. 
 
Added a small fix in branch to address drag and drop on Big Sur. 
