### PR TITLE
rtaudio osx: set deployment-target to osx 10.9

### DIFF
--- a/apothecary/formulas/rtAudio/rtAudio.sh
+++ b/apothecary/formulas/rtAudio/rtAudio.sh
@@ -60,6 +60,7 @@ function build() {
 					 -Iinclude \
 					 -DHAVE_GETTIMEOFDAY \
 					 -D__MACOSX_CORE__ \
+					 -mmacosx-version-min=10.9 \
 					 -c RtAudio.cpp \
 					 -o RtAudio.o
 

--- a/apothecary/formulas/rtAudio/rtAudio.sh
+++ b/apothecary/formulas/rtAudio/rtAudio.sh
@@ -60,7 +60,7 @@ function build() {
 					 -Iinclude \
 					 -DHAVE_GETTIMEOFDAY \
 					 -D__MACOSX_CORE__ \
-					 -mmacosx-version-min=10.9 \
+					 -mmacosx-version-min=${OSX_MIN_SDK_VER} \
 					 -c RtAudio.cpp \
 					 -o RtAudio.o
 


### PR DESCRIPTION
the current rtaudio build emmits a call to "____chkstk_darwin()". but that symbol only exists in osx 10.14+, meaning all OF apps using rtaudio crash in osx up to 10.13. 

the fix is to set the deployment target to 10.9. it supresses chkstk_darwin on intel based builds (the arm64 build is unaffected). 

happy to answer questions, hope this gets accepted quick. 