### PR TITLE
CI build of additional Msys2 flavours

### DIFF
--- a/.github/workflows/build-msys2.yml
+++ b/.github/workflows/build-msys2.yml
@@ -15,13 +15,13 @@ jobs:
     strategy:
       matrix:
           include: [
-            { msystem: MINGW32 },
-            { msystem: MINGW64 },
-            { msystem: UCRT64 },
-            { msystem: CLANG32 },
-            { msystem: CLANG64 }
+            { flavor: mingw32 },
+            { flavor: mingw64 },
+            { flavor: ucrt64 },
+            { flavor: clang32 },
+            { flavor: clang64 }
           ]
-    name: ${{ matrix.msystem }}
+    name: ${{ matrix.flavor }}
     runs-on: windows-2022
     defaults:
       run:
@@ -31,7 +31,7 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           update: true
-          msystem: ${{ matrix.msystem }}
+          msystem: ${{ matrix.flavor }}
           install: >-
             base-devel
             unzip
@@ -40,9 +40,9 @@ jobs:
             git
             libxml2
             python3
-      - name: Install additional msys2 packages
-        run: |
-          pacman -S --noconfirm ${MINGW_PACKAGE_PREFIX}-gcc ${MINGW_PACKAGE_PREFIX}-cmake
+          pacboy: >-
+            gcc:p
+            cmake:p
       - name: Clone repository
         uses: actions/checkout@v2
       - name: Build
@@ -59,6 +59,6 @@ jobs:
           tag: nightly
           release: nightly
           prerelease: false
-          files: out/openFrameworksLibs_master_msys2_mingw64.zip
+          files: out/openFrameworksLibs_master_msys2_${{ matrix.flavor }}.zip
         if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && github.ref == 'refs/heads/master'
 

--- a/.github/workflows/build-msys2.yml
+++ b/.github/workflows/build-msys2.yml
@@ -14,13 +14,14 @@ jobs:
     
     strategy:
       matrix:
-          include: [
-            { flavor: mingw32 },
-            { flavor: mingw64 },
-            { flavor: ucrt64 },
-            { flavor: clang32 },
-            { flavor: clang64 }
-          ]
+        flavor:
+          - mingw32 # Obsolete : kept for backward compatibility
+          - mingw64
+          - ucrt64
+          #- clang32
+          - clang64
+          #- clangarm64
+
     name: ${{ matrix.flavor }}
     runs-on: windows-2022
     defaults:
@@ -31,6 +32,7 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           update: true
+          release : true
           msystem: ${{ matrix.flavor }}
           install: >-
             base-devel
@@ -49,7 +51,6 @@ jobs:
         working-directory: ${{env.GITHUB_WORKSPACE}}
         run: scripts/build.sh
         env:
-          BUNDLE: ${{ matrix.bundle }}
           TARGET: "msys2"
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Update Release

--- a/.github/workflows/build-msys2.yml
+++ b/.github/workflows/build-msys2.yml
@@ -15,15 +15,12 @@ jobs:
     strategy:
       matrix:
         flavor:
-          - mingw32 # Obsolete : kept for backward compatibility
           - mingw64
           - ucrt64
-          #- clang32
           - clang64
           #- clangarm64
-
     name: ${{ matrix.flavor }}
-    runs-on: windows-2022
+    runs-on: windows-latest
     defaults:
       run:
         shell: msys2 {0}

--- a/.github/workflows/build-msys2.yml
+++ b/.github/workflows/build-msys2.yml
@@ -11,7 +11,18 @@ on:
 jobs:
 
   build-msys2:
-    runs-on: windows-2019
+    
+    strategy:
+      matrix:
+          include: [
+            { msystem: MINGW32 },
+            { msystem: MINGW64 },
+            { msystem: UCRT64 },
+            { msystem: CLANG32 },
+            { msystem: CLANG64 }
+          ]
+    name: ${{ matrix.msystem }}
+    runs-on: windows-2022
     defaults:
       run:
         shell: msys2 {0}
@@ -20,6 +31,7 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           update: true
+          msystem: ${{ matrix.msystem }}
           install: >-
             base-devel
             unzip
@@ -27,9 +39,10 @@ jobs:
             gperf
             git
             libxml2
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-cmake
             python3
+      - name: Install additional msys2 packages
+        run: |
+          pacman -S --noconfirm ${MINGW_PACKAGE_PREFIX}-gcc ${MINGW_PACKAGE_PREFIX}-cmake
       - name: Clone repository
         uses: actions/checkout@v2
       - name: Build
@@ -38,8 +51,6 @@ jobs:
         env:
           BUNDLE: ${{ matrix.bundle }}
           TARGET: "msys2"
-          ARCH: 64
-          MSYSTEM: MINGW64
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Update Release
         uses: johnwbyrd/update-release@v1.0.0


### PR DESCRIPTION
Add CI build support for UCRT64 and CLANG64 environment in MSYS2. 
mingw32 flavor kept in the matrix. To be delete when 32 bits support will be officially dropped.