### PR TITLE
remove android from poco formula

### DIFF
--- a/apothecary/formulas/poco/poco.sh
+++ b/apothecary/formulas/poco/poco.sh
@@ -14,7 +14,7 @@ VER=1.10.1-release
 GIT_URL=https://github.com/pocoproject/poco
 GIT_TAG=poco-${VER}
 
-FORMULA_TYPES=( "osx" "ios" "tvos" "android" "emscripten" "vs" "linux" "linux64" )
+FORMULA_TYPES=( "osx" "ios" "tvos" "emscripten" "vs" "linux" "linux64" )
 
 #dependencies
 FORMULA_DEPENDS=( "openssl" )


### PR DESCRIPTION
@danoli3 this is so the CI can pass, but also you mentioned that we might not use Poco going forward for Android 