### PR TITLE
fix broken svgtiny formula that wasn't erroring

### DIFF
--- a/apothecary/formulas/svgtiny/svgtiny.sh
+++ b/apothecary/formulas/svgtiny/svgtiny.sh
@@ -91,7 +91,7 @@ function build() {
 			else
 				vs-build svgtiny.sln Build "Release|x64"
 			fi
-		elif [ $VS_VER -eq 15 ]; then
+		else
 			cd vs2017
 			if [ $ARCH == 32 ] ; then
 				vs-build svgtiny.sln Build "Release|x86"
@@ -168,7 +168,7 @@ function copy() {
 				mkdir -p $1/lib/$TYPE/x64
 				cp -v "vs2015/x64/Release/svgtiny.lib" $1/lib/$TYPE/x64/svgtiny.lib
 			fi
-		elif [ $VS_VER -eq 15 ]; then
+		else
 			if [ $ARCH == 32 ] ; then
 				mkdir -p $1/lib/$TYPE/Win32
 				cp -v "vs2017/Release/svgtiny.lib" $1/lib/$TYPE/Win32/svgtiny.lib

--- a/apothecary/formulas/svgtiny/svgtiny.sh
+++ b/apothecary/formulas/svgtiny/svgtiny.sh
@@ -98,8 +98,6 @@ function build() {
 			else
 				vs-build svgtiny.sln Build "Release|x64"
 			fi
-		else
-			echo "VS Version not supported yet"
 		fi
 
 	elif [ "$TYPE" == "android" ]; then
@@ -176,8 +174,6 @@ function copy() {
 				mkdir -p $1/lib/$TYPE/x64
 				cp -v "vs2017/x64/Release/svgtiny.lib" $1/lib/$TYPE/x64/svgtiny.lib
 			fi
-		else
-			echo "VS Version not supported yet"
 		fi
 
 	elif [ "$TYPE" == "osx" ] || [ "$TYPE" == "ios" ] || [ "$TYPE" == "tvos" ]; then


### PR DESCRIPTION
Turns out svgtiny wasn't being built but also wasn't erroring so it was missing from the packaged libs folder. 
This is due to the CI using newer VS compilers. 