### PR TITLE
fix(svgtiny): compilation on ucrt64

### DIFF
--- a/.github/workflows/build-msys2.yml
+++ b/.github/workflows/build-msys2.yml
@@ -35,13 +35,13 @@ jobs:
             base-devel
             unzip
             dos2unix
-            gperf
             git
-            libxml2
-            python3
           pacboy: >-
             gcc:p
             cmake:p
+            gperf:p
+            libxml2:p
+            python3:p
       - name: Clone repository
         uses: actions/checkout@v2
       - name: Build


### PR DESCRIPTION
fix #247 

use pacboy to install gperf, libxml2, python3