### PR TITLE
add -r flag

### DIFF
--- a/apothecary/formulas/freetype/freetype.sh
+++ b/apothecary/formulas/freetype/freetype.sh
@@ -369,7 +369,7 @@ function build() {
 	    cp apinames $BUILD_DIR/freetype/objs/
 	    emmake make -j${PARALLEL_MAKE}
 	    emmake make install
-	    emcc objs/*.o -o build/$TYPE/lib/libfreetype.bc
+	    emcc -r objs/*.o -o build/$TYPE/lib/libfreetype.bc
 		echo "-----------"
 		echo "$BUILD_DIR"
 


### PR DESCRIPTION
Produce a relocatable object as output (partial linking). Necessary for latest emsdk.