### PR TITLE
compile FreeImage with c++11

### DIFF
--- a/apothecary/formulas/FreeImage/FreeImage.sh
+++ b/apothecary/formulas/FreeImage/FreeImage.sh
@@ -333,6 +333,7 @@ function build() {
         cat $BUILD_DIR/FreeImage/Source/LibJXR/image/decode/segdec.c >> $BUILD_DIR/FreeImagePatched/Source/LibJXR/image/decode/segdec.c
         echo "#include <wchar.h>" > $BUILD_DIR/FreeImagePatched/Source/LibJXR/jxrgluelib/JXRGlueJxr.c
         cat $BUILD_DIR/FreeImage/Source/LibJXR/jxrgluelib/JXRGlueJxr.c >> $BUILD_DIR/FreeImagePatched/Source/LibJXR/jxrgluelib/JXRGlueJxr.c
+        sed -i "s/CXXFLAGS ?=/CXXFLAGS ?= -std=c++11/g" "$BUILD_DIR/FreeImage/Makefile.gnu" 
         cd $BUILD_DIR/FreeImagePatched
         emmake make clean -f Makefile.gnu
         emmake make -j${PARALLEL_MAKE} -f Makefile.gnu libfreeimage.a


### PR DESCRIPTION
This fixes compilation errors with latest emsdk, since unpatched FreeImage is not cpp17 compatible

this PR fixes the issue by compiling FreeImage with cpp11. openFrameworks + other libraries can still be compiled with cpp17, and will be compatible with the produced binary.

there is be a second PR (#254) which fixes the same issue by compiling FreeImage from a newer, patched branch
not entirely sure what has preference, so i simply made both PR's, and you can chose. hope that's okay!

check discussion here: https://github.com/openframeworks/apothecary/issues/244