### PR TITLE
GLM from master

### DIFF
--- a/apothecary/formulas/glm/glm.sh
+++ b/apothecary/formulas/glm/glm.sh
@@ -9,7 +9,8 @@ FORMULA_TYPES=( "osx" "linux" "linux64" "linuxarmv6l" "linuxarmv7l" "linuxaarch6
 
 # tools for git use
 GIT_URL=https://github.com/g-truc/glm
-GIT_TAG=0.9.9.7
+#GIT_TAG=0.9.9.7
+GIT_TAG=master
 
 # download the source code and unpack it into LIB_NAME
 function download() {


### PR DESCRIPTION
I've noticed GLM fixed this kind of warning, but it is not yet on any release (2020 was most recent) so I'm using latest from master 
```
In file included from /Volumes/tool/ofw/apps/WerkApps/Scenes/src/main.cpp:19:
In file included from src/ofApp.h:3:
In file included from ../../../libs/openFrameworks/ofMain.h:19:
In file included from ../../../libs/openFrameworks/utils/ofJson.h:8:
In file included from ../../../libs/openFrameworks/types/ofParameter.h:8:
In file included from ../../../libs/openFrameworks/types/ofColor.h:4:
In file included from ../../../libs/glm/include/glm/gtx/wrap.hpp:16:
In file included from ../../../libs/glm/include/glm/gtx/../glm.hpp:132:
In file included from ../../../libs/glm/include/glm/packing.hpp:173:
In file included from ../../../libs/glm/include/glm/detail/func_packing.inl:5:
In file included from ../../../libs/glm/include/glm/./ext/../detail/type_half.hpp:16:
../../../libs/glm/include/glm/./ext/../detail/type_half.inl:9:6: warning: compound assignment to object of volatile-qualified type 'volatile float' is deprecated [-Wdeprecated-volatile]
                        f *= f; // this will overflow before the for loop terminates
```