### PR TITLE
Latest Libraries - VS2022 linker fixes - ARM64EC 

### DIFF
--- a/.github/workflows/build-vs2022_arm64.yml
+++ b/.github/workflows/build-vs2022_arm64.yml
@@ -1,0 +1,73 @@
+name: build-vs2022-arm64
+
+on:
+  push:
+    paths-ignore:
+    - '**/*.md'
+  pull_request:
+    paths-ignore:
+    - '**/*.md'
+    
+jobs:
+
+  build-vs2022:
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        bundle: [1,2,3,4]
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - name: Setup msys2
+      uses: msys2/setup-msys2@v2
+      with:
+        update: true
+        install: >-
+          base-devel
+          unzip
+          dos2unix
+          gperf
+          git
+          python3
+          mingw-w64-x86_64-binutils
+          mingw-w64-x86_64-clang
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-gcc-libs
+          mingw-w64-x86_64-cmake
+          mingw-w64-x86_64-gdb
+          mingw-w64-x86_64-make
+    - name: Clone repository
+      uses: actions/checkout@v4
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1.1
+    - name: Determine Release
+      id: vars
+      shell: bash
+      run: |
+        if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+          echo "release=nightly" >> $GITHUB_ENV
+          echo "prerelease=false" >> $GITHUB_ENV
+        elif [[ "${{ github.ref }}" == "refs/heads/bleeding" ]]; then
+          echo "release=bleeding" >> $GITHUB_ENV
+          echo "prerelease=true" >> $GITHUB_ENV
+        fi
+    - name: BuildARM64
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: scripts/build.sh
+      env:
+        BUNDLE: ${{ matrix.bundle }}
+        TARGET: "vs"
+        ARCH: arm64
+        VS_VER: 17
+        GA_CI_SECRET: ${{ secrets.CI_SECRET }}
+    - name: Update Release ARM64
+      if: (github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding'))
+      uses: johnwbyrd/update-release@v1.0.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ env.release }}
+        release: ${{ env.release }}
+        prerelease: ${{ env.prerelease }}
+        files: out/openFrameworksLibs_${{ env.release }}_vs_arm64_${{ matrix.bundle }}.zip
+

--- a/.github/workflows/build-vs2022_arm64ec.yml
+++ b/.github/workflows/build-vs2022_arm64ec.yml
@@ -1,4 +1,4 @@
-name: build-vs2022-arm64
+name: build-vs2022-arm64ec
 
 on:
   push:
@@ -39,8 +39,6 @@ jobs:
           mingw-w64-x86_64-make
     - name: Clone repository
       uses: actions/checkout@v4
-    #- name: Install StrawberryPerl
-    #  run: choco install -y strawberryperl
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.1
     - name: Determine Release
@@ -54,25 +52,16 @@ jobs:
           echo "release=bleeding" >> $GITHUB_ENV
           echo "prerelease=true" >> $GITHUB_ENV
         fi
-    - name: Build64
+    - name: BuildARM64EC
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: scripts/build.sh
       env:
         BUNDLE: ${{ matrix.bundle }}
         TARGET: "vs"
-        ARCH: 64
+        ARCH: arm64ec
         VS_VER: 17
         GA_CI_SECRET: ${{ secrets.CI_SECRET }}
-    - name: BuildARM64
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: scripts/build.sh
-      env:
-        BUNDLE: ${{ matrix.bundle }}
-        TARGET: "vs"
-        ARCH: arm64
-        VS_VER: 17
-        GA_CI_SECRET: ${{ secrets.CI_SECRET }}
-    - name: Update Release 64
+    - name: Update Release ARM64EC
       if: (github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding'))
       uses: johnwbyrd/update-release@v1.0.0
       with:
@@ -80,14 +69,5 @@ jobs:
         tag: ${{ env.release }}
         release: ${{ env.release }}
         prerelease: ${{ env.prerelease }}
-        files: out/openFrameworksLibs_${{ env.release }}_vs_64_${{ matrix.bundle }}.zip
-    - name: Update Release ARM64
-      if: (github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding'))
-      uses: johnwbyrd/update-release@v1.0.0
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ env.release }}
-        release: ${{ env.release }}
-        prerelease: ${{ env.prerelease }}
-        files: out/openFrameworksLibs_${{ env.release }}_vs_arm64_${{ matrix.bundle }}.zip
+        files: out/openFrameworksLibs_${{ env.release }}_vs_arm64ec_${{ matrix.bundle }}.zip
 

--- a/.github/workflows/build-vs2022_x64.yml
+++ b/.github/workflows/build-vs2022_x64.yml
@@ -1,0 +1,73 @@
+name: build-vs2022-64
+
+on:
+  push:
+    paths-ignore:
+    - '**/*.md'
+  pull_request:
+    paths-ignore:
+    - '**/*.md'
+    
+jobs:
+
+  build-vs2022:
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        bundle: [1,2,3,4]
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - name: Setup msys2
+      uses: msys2/setup-msys2@v2
+      with:
+        update: true
+        install: >-
+          base-devel
+          unzip
+          dos2unix
+          gperf
+          git
+          python3
+          mingw-w64-x86_64-binutils
+          mingw-w64-x86_64-clang
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-gcc-libs
+          mingw-w64-x86_64-cmake
+          mingw-w64-x86_64-gdb
+          mingw-w64-x86_64-make
+    - name: Clone repository
+      uses: actions/checkout@v4
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1.1
+    - name: Determine Release
+      id: vars
+      shell: bash
+      run: |
+        if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+          echo "release=nightly" >> $GITHUB_ENV
+          echo "prerelease=false" >> $GITHUB_ENV
+        elif [[ "${{ github.ref }}" == "refs/heads/bleeding" ]]; then
+          echo "release=bleeding" >> $GITHUB_ENV
+          echo "prerelease=true" >> $GITHUB_ENV
+        fi
+    - name: Build64
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: scripts/build.sh
+      env:
+        BUNDLE: ${{ matrix.bundle }}
+        TARGET: "vs"
+        ARCH: 64
+        VS_VER: 17
+        GA_CI_SECRET: ${{ secrets.CI_SECRET }}
+    - name: Update Release 64
+      if: (github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding'))
+      uses: johnwbyrd/update-release@v1.0.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ env.release }}
+        release: ${{ env.release }}
+        prerelease: ${{ env.prerelease }}
+        files: out/openFrameworksLibs_${{ env.release }}_vs_64_${{ matrix.bundle }}.zip
+

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -478,15 +478,15 @@ if [ "$TYPE" = "vs" ]; then
             CROSS_TOOL="all"
         fi        
     fi
-    WIN_CRT=MD #MT
+    WIN_CRT=/MD
      if [ $VS_COMPILER == "LLVM" ]; then
         export VS_C_FLAGS="-Wno-error" # warnings will not be treated as errors
+        export EXCEPTION_FLAGS="-fexceptions"
     else
         export VS_C_FLAGS="/WX-"
-        export CXX_FLAGS_RELEASE="/${WIN_CRT}"
-        export C_FLAGS_RELEASE="/${WIN_CRT}"
-        export CXX_FLAGS_DEBUG="/${WIN_CRT}d"
-        export C_FLAGS_DEBUG="/${WIN_CRT}d"
+        export FLAGS_RELEASE="${WIN_CRT}"
+        export FLAGS_DEBUG="${WIN_CRT}d"
+        export EXCEPTION_FLAGS="/EHsc"
     fi
 
     if [ $VS_VER == "17" ]; then
@@ -494,9 +494,9 @@ if [ "$TYPE" = "vs" ]; then
     	VS_VER=17
     	VS_VER_GEN="$VS_VER $VS_YEAR"
         if [ $ARCH == "arm64ec" ] || [ $TARGET_WIN_11 == 1 ]; then
-            export CMAKE_WIN_SDK="-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=${WIN11_INSTALLED_SDK_2022} -DCMAKE_SYSTEM_VERSION=${WIN11_INSTALLED_SDK_2022}"
+            export CMAKE_WIN_SDK="-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=${WIN11_INSTALLED_SDK_2022} -DCMAKE_SYSTEM_VERSION=${WIN11_INSTALLED_SDK_2022} "
         else 
-            export CMAKE_WIN_SDK="-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=${WIN10_INSTALLED_SDK_2022} -DCMAKE_SYSTEM_VERSION=${WIN10_INSTALLED_SDK_2022}"
+            export CMAKE_WIN_SDK="-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=${WIN10_INSTALLED_SDK_2022} -DCMAKE_SYSTEM_VERSION=${WIN10_INSTALLED_SDK_2022} "
         fi
     else
     	VS_YEAR=2019

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -70,7 +70,7 @@ SAVE_SCRIPT="$(realpath "$APOTHECARY_DIR/../scripts/save.sh")"
 LOAD_SCRIPT="$(realpath "$APOTHECARY_DIR/../scripts/load.sh")"
 SAVE_FILE="$(realpath "$APOTHECARY_DIR/../scripts")/status.txt"
 
-USE_SAVE=0
+USE_SAVE=1
 
 ### Xcode/ios specific settings
 
@@ -105,10 +105,6 @@ echo "This script is run from \"$thisDir\""
 
 fi
 
-# if [ "$(${APOTHECARY_DIR}/ostype.sh)" == "osx" ] && [[ "$TYPE" == "linuxarmv6l" ] || [ "$TYPE" == "linuxarmv7l" ]]; then
-
-# fi
-
 BUILD_MACHINE_ARCH=`uname -m`
 
 # paths to android SDK, etc
@@ -118,8 +114,6 @@ NDK_VERSION=24
 NDK_VERSION_MAJOR=24
 ANDROID_API=21
 ANDROID_PLATFORM=android-${ANDROID_API}
-
-
 
 ################################################################################
 ### PRIVATE VARS, for internal use
@@ -153,7 +147,6 @@ echo "REL_ADDONS_DIR: $REL_ADDONS_DIR"
 
 CHECKOUT=YES
 
-
 # ansi console escape codes
 CON_DEFAULT="\033[0m"
 CON_BOLD="\033[1m"
@@ -181,7 +174,10 @@ VS_BUILD_TOOL=devenv
 WIN10_INSTALLED_SDK_2019=10.0.190410.0
 WIN10_INSTALLED_SDK_2022=10.0.20348.0
 WIN11_INSTALLED_SDK_2022=10.0.22621.0
-VS_TYPE=Community
+VS_TYPE=Community #Professional #Enterprise 
+VS_COMPILER=MSVC #Compiler - MSVC by Default - Clang LLVM available now
+VS_HOST=amd64
+TARGET_WIN_11=0
 
 # nice, detailed help message
 HELP="usage: apothecary [options] <command> [<core|addons|libName|addonName>]
@@ -201,6 +197,7 @@ commands:
   remove	remove the library from the build cache
   remove-lib	remove the library from the libs dir
   remove-all	remove the library from the build cache and libs dir
+  framework     build frameworks 
 
 options:
   -t	specify libary type when building, detects type from OS by default
@@ -323,7 +320,7 @@ echoVerbose() {
 #### PARSE COMMANDLINE
 
 # from http://www.mkssoftware.com/docs/man1/getopts.1.asp
-while getopts t:a:b:d:s:j:hgvfpe opt ; do
+while getopts t:a:b:d:s:j:c:hgvfpew opt ; do
 	case "$opt" in
 		t) # set the library build type
 		   export TYPE="$OPTARG" ;;
@@ -349,6 +346,10 @@ while getopts t:a:b:d:s:j:hgvfpe opt ; do
            export FORCE_DOWNLOAD=1 ;;
 		p) # Dont build dependencies
            export BUILD_DEPENDENCIES=0 ;;
+        w) # win11
+           export TARGET_WIN_11=1 ;;
+        c) # host compiler
+           export VS_COMPILER="$OPTARG" ;;
 		[?]) # print help and exit
 			echo "$HELP" ; exit 0 ;;
 	esac
@@ -386,18 +387,15 @@ function setup_vs_vars(){
         MSBUILD_PATH="${VS_INSTALL_PATH}\MSBuild\\${VS_VER}.0\Bin\MSBuild.exe"
         echo "-- Found MSBuild path: ${MSBUILD_PATH}"
 
-        VS_VER_DIR=$(ls "$VS_BASE_PATH/VC/Tools/MSVC/" | tail -1)
-        if [ $ARCH == "arm64" ] || [ $ARCH == "ARM" ]; then
-            export VS_BIN_PATH="$VS_BASE_PATH/VC/Tools/MSVC/$VS_VER_DIR/bin/$VS_HOSTPLATFORM/$BUILD_PLATFORM"
+        VS_VER_DIR=$(ls "$VS_BASE_PATH/VC/Tools/${VS_COMPILER}/" | tail -1)
+        if [ $ARCH == "arm64" ] || [ $ARCH == "ARM" ] || [ $ARCH == "arm64ec" ]; then
+            export VS_BIN_PATH="$VS_BASE_PATH/VC/Tools/${VS_COMPILER}/$VS_VER_DIR/bin/$VS_HOSTPLATFORM/$BUILD_PLATFORM"
         else 
-            export VS_BIN_PATH="$VS_BASE_PATH/VC/Tools/MSVC/$VS_VER_DIR/bin/$VS_HOSTPLATFORM/$BUILD_PLATFORM"
+            export VS_BIN_PATH="$VS_BASE_PATH/VC/Tools/${VS_COMPILER}/$VS_VER_DIR/bin/$VS_HOSTPLATFORM/$BUILD_PLATFORM"
         fi
-
         echo "VS_BIN_PATH was not set - setting to $VS_BIN_PATH"
 
         export PATH=$VS_BIN_PATH:$PATH
-
-
         (
             # with parentheses we open a new sub-shell scope to make sure we're not overwriting any presets for IFS
             # set input field separator to colon (:) for current scope
@@ -446,14 +444,10 @@ function with_vs_env(){
     fi
 }
 
-
-
 # used when building for vs - set to 16 if not set explicitly
 if [ "$TYPE" = "vs" ]; then
-
     if [ -z ${VS_VER+x} ]; then 
-           
-        if [ $ARCH == "arm64" ]; then
+        if [ $ARCH == "arm64" ] || [ $ARCH == "arm64ec" ]; then
             VS_VER=17
         else
             VS_VER=17
@@ -461,70 +455,72 @@ if [ "$TYPE" = "vs" ]; then
         fi 
         echo "VS_VER was not set - setting to ${VS_VER}"
     fi
-
-
     VS_64_BIT_ENV='VC\vcvarsall'
-
-
     if [ -z ${PLATFORM+x}]; then
         if [ $ARCH == "32" ]; then
             PLATFORM=x86
             CROSS_TOOL="amd64_x86"
-            VS_HOST=amd64
         elif [ $ARCH == "64" ]; then
             PLATFORM=x64
             CROSS_TOOL="amd64"
-            VS_HOST=amd64
         elif [ $ARCH == "arm64" ]; then
             PLATFORM=x64
-            VS_HOST=amd64
+            CROSS_TOOL="all"
+        elif [ $ARCH == "arm64ec" ]; then
+            PLATFORM=x64
             CROSS_TOOL="all"
         elif [ $ARCH == "arm" ]; then
             PLATFORM=x64
-            VS_HOST=amd64
             CROSS_TOOL="all"
         else
         	echo "ARCH not set $ARCH"
         	PLATFORM=x64
             CROSS_TOOL="all"
-            VS_HOST=amd64
         fi        
     fi
-
     WIN_CRT=MD #MT
+     if [ $VS_COMPILER == "LLVM" ]; then
+        export VS_C_FLAGS="-Wno-error" # warnings will not be treated as errors
+    else
+        export VS_C_FLAGS="/WX-"
+        export CXX_FLAGS_RELEASE="/${WIN_CRT}"
+        export C_FLAGS_RELEASE="/${WIN_CRT}"
+        export CXX_FLAGS_DEBUG="/${WIN_CRT}d"
+        export C_FLAGS_DEBUG="/${WIN_CRT}d"
+    fi
 
     if [ $VS_VER == "17" ]; then
     	VS_YEAR=2022
     	VS_VER=17
     	VS_VER_GEN="$VS_VER $VS_YEAR"
-        #export CMAKE_WIN_SDK="-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=${WIN10_INSTALLED_SDK_2022} -DCMAKE_SYSTEM_VERSION=${WIN10_INSTALLED_SDK_2022}-DCMAKE_CXX_FLAGS_RELEASE=\"/${WIN_CRT}\" -DCMAKE_C_FLAGS_RELEASE=\"/${WIN_CRT}\" -DCMAKE_CXX_FLAGS_DEBUG=\"/${WIN_CRT}d\" -DCMAKE_C_FLAGS_DEBUG=\"/${WIN_CRT}d\""
-        export CMAKE_WIN_SDK="-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=${WIN10_INSTALLED_SDK_2022} -DCMAKE_SYSTEM_VERSION=${WIN10_INSTALLED_SDK_2022} "
-    
+        if [ $ARCH == "arm64ec" ] || [ $TARGET_WIN_11 == 1 ]; then
+            export CMAKE_WIN_SDK="-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=${WIN11_INSTALLED_SDK_2022} -DCMAKE_SYSTEM_VERSION=${WIN11_INSTALLED_SDK_2022}"
+        else 
+            export CMAKE_WIN_SDK="-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=${WIN10_INSTALLED_SDK_2022} -DCMAKE_SYSTEM_VERSION=${WIN10_INSTALLED_SDK_2022}"
+        fi
     else
     	VS_YEAR=2019
     	VS_VER=16
     	VS_VER_GEN="$VS_VER $VS_YEAR"
-        export CMAKE_WIN_SDK="-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=${WIN10_INSTALLED_SDK_2019} -DCMAKE_SYSTEM_VERSION=${WIN10_INSTALLED_SDK_2019}"
+        export CMAKE_WIN_SDK="-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=${WIN10_INSTALLED_SDK_2019} -DCMAKE_SYSTEM_VERSION=${WIN10_INSTALLED_SDK_2019} "
 	fi    
-
 	echo "PLATFORM set to ${PLATFORM} Visual Studio ${VS_VER_GEN} - ${CROSS_TOOL} - ${VS_HOST}"
-    
     VS_BAT="vcvarsall.bat"
-
-    if [ -z "${WSL_DISTRO_NAME+x}" ]
-	then
+    if [ -z "${WSL_DISTRO_NAME+x}" ]; then
 		DRIVE=/c
 	else
 	  	DRIVE=/mnt/c
 	fi 
-
     if [ -z ${VS_HOSTPLATFORM+x} ]; then
-        VS_HOSTPLATFORM=Hostx64
-    #else
-    #    VS_HOSTPLATFORM=Hostx64
+        if [ ${VS_HOST} == "amd64" ]; then
+            VS_HOSTPLATFORM=Hostx64
+        elif [ ${VS_HOST} == "86" ]; then
+            VS_HOSTPLATFORM=Hostx86
+        else
+            #else if arm or arm64 which is same as VS_HOST
+            VS_HOSTPLATFORM=${VS_HOST}
+        fi
     fi
-
-
     if [ -z ${VS_BASE_PATH+x} ]; then
         if [ "${VS_VER}" = "15" ]; then
             VS_BASE_PATH="${DRIVE}/Program Files (x86)/Microsoft Visual Studio/2017/$VS_TYPE"
@@ -540,85 +536,53 @@ if [ "$TYPE" = "vs" ]; then
 			  VS_YEAR_PATH=2019
 			  VC_VERSION=142
 			fi
-
-        	# if [ $ARCH == "arm64" ]; then
-        	# 	VS_BASE_PATH="${DRIVE}/Program Files/Microsoft Visual Studio/2022/$VS_TYPE"
-          	# 	VS_YEAR=2019
-          	# 	VC_VERSION=142
-        	# else
-            	VS_BASE_PATH="${DRIVE}/Program Files (x86)/Microsoft Visual Studio/$VS_YEAR_PATH/$VS_TYPE"
-            	VS_YEAR=$VS_YEAR_PATH
-        	# fi
+            VS_BASE_PATH="${DRIVE}/Program Files (x86)/Microsoft Visual Studio/$VS_YEAR_PATH/$VS_TYPE"
+        	VS_YEAR=$VS_YEAR_PATH
         elif [ "${VS_VER}" = "17" ]; then
-
           	VS_BASE_PATH="${DRIVE}/Program Files/Microsoft Visual Studio/2022/$VS_TYPE"
           	VS_YEAR=2022
           	VC_VERSION=143
             VS_BAT="vcvars$ARCH.bat"
-             #VS_BASE_PATH="${DRIVE}/Program Files (x86)/Microsoft Visual Studio/$VS_YEAR_PATH/$VS_TYPE"
         fi
     fi
-
     if [ $ARCH == 32 ] ; then
         BUILD_PLATFORM="x86"
     elif [ $ARCH == 64 ] ; then
         BUILD_PLATFORM="x64"
     elif [ $ARCH == "arm64" ] ; then
         BUILD_PLATFORM="arm64"
+    elif [ $ARCH == "arm64ec" ] ; then
+        BUILD_PLATFORM="arm64"
     elif [ $ARCH == "arm" ]; then
         BUILD_PLATFORM="arm"
     fi 
-
     if [ $ARCH == 32 ] ; then
         PLATFORM="Win32"
     elif [ $ARCH == 64 ] ; then
         PLATFORM="x64"
     elif [ $ARCH == "arm64" ] ; then
         PLATFORM="ARM64"
+    elif [ $ARCH == "arm64ec" ] ; then
+        PLATFORM="arm64ec"
     elif [ $ARCH == "arm" ]; then
         PLATFORM="ARM"
     fi 
-	
-
-
-	if [ $ARCH == "arm64" ] || [ $ARCH == "ARM" ]; then
-           
+	if [ $ARCH == "arm64" ] || [ $ARCH == "arm64ec" ] || [ $ARCH == "ARM" ]; then
 		VS_VARS_PATH=$(cygpath -wa "$VS_BASE_PATH/VC/Auxiliary/Build/vcvarsall.bat")
-
 	else 
 		VS_VARS_PATH=$(cygpath -wa "$VS_BASE_PATH/VC/Auxiliary/Build/$VS_BAT")
-
 	fi
-
     echo "VS_VARS_PATH: $VS_VARS_PATH"
-
-    #setup_vs_vars 
-    #cmd.exe \/c "call \"%VS${VS_VER}0COMNTOOLS%..\\..\\${VS_64_BIT_ENV}\" amd64 && $@"
-
-    # echo "vspath:$VS_BASE_PATH"
-    #echo "vspath:$VS_VARS_PATH"
-    #cmd.exe \/c "call \"${VS_VARS_PATH}\""
-
-
-	#export VS_BASE_PATH; 
-	#export VS_VARS_PATH;
-    #export VS_YEAR;
-
-
     if [ -z ${VS_BIN_PATH+x} ]; then	            
-		VS_VER_DIR=$(ls "$VS_BASE_PATH/VC/Tools/MSVC/" | tail -1)
+		VS_VER_DIR=$(ls "$VS_BASE_PATH/VC/Tools/${VS_COMPILER}/" | tail -1)
 
-        if [ $ARCH == "arm64" ] || [ $ARCH == "ARM" ]; then
-            export VS_BIN_PATH="$VS_BASE_PATH/VC/Tools/MSVC/$VS_VER_DIR/bin/$VS_HOSTPLATFORM/$BUILD_PLATFORM"
+        if [ $ARCH == "arm64" ] || [ $ARCH == "ARM" ] || [ $ARCH == "arm64ec" ]; then
+            export VS_BIN_PATH="$VS_BASE_PATH/VC/Tools/${VS_COMPILER}/$VS_VER_DIR/bin/$VS_HOSTPLATFORM/$BUILD_PLATFORM"
         else 
-            export VS_BIN_PATH="$VS_BASE_PATH/VC/Tools/MSVC/$VS_VER_DIR/bin/$VS_HOSTPLATFORM/$BUILD_PLATFORM"
+            export VS_BIN_PATH="$VS_BASE_PATH/VC/Tools/${VS_COMPILER}/$VS_VER_DIR/bin/$VS_HOSTPLATFORM/$BUILD_PLATFORM"
         fi
-
-        
         echo "VS_BIN_PATH was not set - setting to $VS_BIN_PATH"
-
 		export PATH=$VS_BIN_PATH:$PATH
-
         (
         	# with parentheses we open a new sub-shell scope to make sure we're not overwriting any presets for IFS
 	        # set input field separator to colon (:) for current scope
@@ -634,9 +598,6 @@ if [ "$TYPE" = "vs" ]; then
 
 	        done
         )
-
-        
-
         # Test for existence of directory where cmake should live
         # then prepend cmake path to PATH
         if [ -d "/c/Program Files/CMake/bin/" ]; then
@@ -648,6 +609,8 @@ if [ "$TYPE" = "vs" ]; then
     #echo "NEW PATH: $PATH"
 fi
 
+####  Platform Determination for Targets
+
 if [ "$TYPE" = "msys2" ]; then
     if [ -z ${PLATFORM+x}]; then
         if [ $ARCH == "32" ]; then
@@ -655,7 +618,7 @@ if [ "$TYPE" = "msys2" ]; then
         elif [ $ARCH == "64" ]; then
             PLATFORM=x64
         elif [ $ARCH == "arm64" ]; then
-            PLATFORM=x64
+            PLATFORM=arm64
         elif [ $ARCH == "arm" ]; then
             PLATFORM=x64
         else
@@ -1071,12 +1034,11 @@ function updateFormula() {
 
 	if [ $USE_SAVE == 1 ]; then
 		if load $1; then
-		   echoInfo "Skipping build as already done for this target "
+		   echoInfo "Skipping - target ${1} already built and up to date"
 		else
-		    echoVerbose "The entry doesn't exist or needs to be rebuilt."
+		    echoVerbose "Building ${1} as deployed library doesn't exist or does needs to be rebuilt as out of date."
 		    buildFormula $1
 		    copyFormula $1
-
 		    save $1
 		fi
 	else
@@ -1183,22 +1145,12 @@ function buildFormula() {
 
 	# dependencies
 	if [ $FORMULA_DEPENDS_MANUAL == 0 ] ; then
-
-		if [ $USE_SAVE == 1 ]; then
-			if apothecaryDependencies load $1; then
-		    	echoInfo "Skipping build apothecaryDependency as already done for this target "
-			else
-				echoVerbose "apothecaryDependency The entry doesn't exist or needs to be rebuilt."       
-				apothecaryDependencies build
-				apothecaryDependencies copy
-				apothecaryDependencies save
-			fi
-		else
-			apothecaryDependencies build
-			apothecaryDependencies copy
-		fi
+		apothecaryDependencies build
+		apothecaryDependencies copy
+        echoInfo "apothecaryDependency built "
+        echoInfo " Now Building \"$1\""
 	fi
-
+    echoInfo "--------------------"
 	build $1
 
 	cd $APOTHECARY_DIR
@@ -1387,8 +1339,9 @@ function vs-build() {
 			DEFAULT_BUILD="Release|ARM"
 		elif [ $ARCH == "arm64" ] ; then
 			DEFAULT_BUILD="Release|ARM64"
+        elif [ $ARCH == "arm64ec" ] ; then
+            DEFAULT_BUILD="Release|ARM64EC"
 		fi
-	
 
 		# Cut part before '|' character of third parameter (which defaults to "Default|x64") and store it as BUILD_CONFIGURATION
 		BUILD_CONFIGURATION="$( cut -d '|' -f 1 <<< "${3:-$DEFAULT_BUILD}" )"
@@ -1492,41 +1445,40 @@ function load() {
 # $1 = command
 # $2 = dependency name
 function apothecaryDepend() {
-	# Dont do anything if BUILD_DEPENDENCIES is false
-	if [ $BUILD_DEPENDENCIES == 0 ] ; then
+    # Don't do anything if BUILD_DEPENDENCIES is false
+    if [ $BUILD_DEPENDENCIES == 0 ] ; then
         echoInfo " ... skipping depend BUILD_DEPENDENCIES == 0 $depend"
-		return
-	fi
+        return
+    fi
 
     local ROOT=$PWD
-	local depend="${2%.*}" # removes extension
+    local depend="${2%.*}" # removes extension
 
-	# detect if dependency is a main OF lib
-	if [ -f $FORMULAS_DIR/$depend.sh -o -d $FORMULAS_DIR/$depend ] ; then
+    # Detect if dependency is a main OF lib or a dependency
+    if [ -f $FORMULAS_DIR/$depend.sh -o -d $FORMULAS_DIR/$depend ] || [ -f $DEPENDS_FORMULA_DIR/$depend.sh -o -d $DEPENDS_FORMULA_DIR/$depend ] ; then
+        :
+    else
+        echoError " Cannot $1, no formula for dependency \"$depend\""
+        exit 1
+    fi
 
-		# don't remove main OF libs if they are dependencies
-		if [ "$1" == "remove" -o "$1" == "remove-lib" -o "$1" == "remove-all" ] ; then
-			echoVerbose " ... skipping main lib dependency $depend"
-			return
-		fi
+    # Skip building if dependency is already up to date
+    if [ $USE_SAVE == 1 ] && load $depend ; then
+        echoInfo "Skipping - dependency $depend already built and up to date"
+        return
+    fi
 
-	# a dependency
-	elif [ -f $DEPENDS_FORMULA_DIR/$depend.sh -o -d $DEPENDS_FORMULA_DIR/$depend ] ; then
-		: # noop
-
-	else
-		echoError " Cannot $1, no formula for dependency \"$depend\""
-		exit 1
-	fi
-
-	# Uses git IF the USE_GIT variable is set
+    # Use git if the USE_GIT variable is set
     if [ $FORCE_DOWNLOAD -eq 1 ]; then
-	    $APOTHECARY_SCRIPT -f -t $TYPE -a $ARCH -j$PARALLEL_MAKE ${USE_GIT:+-g} $1 $depend
+        $APOTHECARY_SCRIPT -f -t $TYPE -a $ARCH -j$PARALLEL_MAKE ${USE_GIT:+-g} $1 $depend
     else
         $APOTHECARY_SCRIPT -t $TYPE -a $ARCH -j$PARALLEL_MAKE ${USE_GIT:+-g} $1 $depend
     fi
+
+    # Return to the original directory
     cd $ROOT
 }
+
 
 # do a command on all formula dependencies in separate apothecary runs
 # $1 = command

--- a/apothecary/formulas/FreeImage/FreeImage.sh
+++ b/apothecary/formulas/FreeImage/FreeImage.sh
@@ -218,13 +218,6 @@ function build() {
 		mkdir -p "build_${TYPE}_${ARCH}"
 		cd "build_${TYPE}_${ARCH}"
         DEFS="-DLIBRARY_SUFFIX=${ARCH}"	
-
-
-        if [ "$VS_COMPILER" == "LLVM" ]; then
-			EXCEPTION_FLAGS="-fexceptions"
-		else
-			EXCEPTION_FLAGS="/EHsc"
-		fi
 		cmake  .. ${DEFS} \
 		-DCMAKE_C_STANDARD=17 \
 		-DCMAKE_CXX_STANDARD=17 \

--- a/apothecary/formulas/FreeImage/FreeImage.sh
+++ b/apothecary/formulas/FreeImage/FreeImage.sh
@@ -212,17 +212,24 @@ function build() {
 		cd ..
 
     elif [ "$TYPE" == "vs" ]; then
-		echo "building $TYPE | $ARCH | $VS_VER | vs: $VS_VER_GEN"
+		echo "building $TYPE | $ARCH | $VS_VER | vs: $VS_VER_GEN platform: $PLATFORM"
         echo "--------------------"
         GENERATOR_NAME="Visual Studio ${VS_VER_GEN}"
 		mkdir -p "build_${TYPE}_${ARCH}"
 		cd "build_${TYPE}_${ARCH}"
         DEFS="-DLIBRARY_SUFFIX=${ARCH}"	
+
+
+        if [ "$VS_COMPILER" == "LLVM" ]; then
+			EXCEPTION_FLAGS="-fexceptions"
+		else
+			EXCEPTION_FLAGS="/EHsc"
+		fi
 		cmake  .. ${DEFS} \
 		-DCMAKE_C_STANDARD=17 \
 		-DCMAKE_CXX_STANDARD=17 \
 		-DCMAKE_CXX_STANDARD_REQUIRED=ON \
-		-DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1" \
+		-DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${EXCEPTION_FLAGS}" \
 		-DCMAKE_C_FLAGS="-DUSE_PTHREADS=1" \
 		-DCMAKE_CXX_EXTENSIONS=OFF \
 		-DBUILD_SHARED_LIBS=OFF \

--- a/apothecary/formulas/assimp.sh
+++ b/apothecary/formulas/assimp.sh
@@ -175,8 +175,8 @@ function build() {
             ${CMAKE_WIN_SDK} \
             -G "${GENERATOR_NAME}" \
             -DCMAKE_INSTALL_PREFIX=. \
-            -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${VS_C_FLAGS}" \
-            -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${VS_C_FLAGS}" \
+            -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${VS_C_FLAGS} ${EXCEPTION_FLAGS}" \
+            -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${VS_C_FLAGS} ${EXCEPTION_FLAGS}" \
             -DASSIMP_BUILD_ZLIB=OFF \
             -DZLIB_ROOT=${ZLIB_ROOT} \
             -DZLIB_INCLUDE_DIR=${ZLIB_INCLUDE_DIR} \

--- a/apothecary/formulas/assimp.sh
+++ b/apothecary/formulas/assimp.sh
@@ -61,10 +61,12 @@ function build() {
         cd "build_${TYPE}_${PLATFORM}"
 
         DEFS="
-            -DASSIMP_BUILD_TESTS=0
-            -DASSIMP_BUILD_SAMPLES=0
-            -DASSIMP_BUILD_3MF_IMPORTER=0
-            -DASSIMP_BUILD_ZLIB=OFF"
+            -DASSIMP_BUILD_TESTS=OFF
+            -DASSIMP_BUILD_SAMPLES=OFF
+            -DASSIMP_BUILD_3MF_IMPORTER=OFF
+            -DASSIMP_BUILD_ZLIB=OFF
+            -DASSIMP_WARNINGS_AS_ERRORS=OFF
+            "
 
         cmake .. ${DEFS} \
             -DCMAKE_C_STANDARD=17 \
@@ -140,19 +142,15 @@ function build() {
             -D CMAKE_VERBOSE_MAKEFILE=ON
 
         cmake --build . --config Release
-
         cd ..      
-       
         #cleanup to not fail if the other platform is called
         rm -f CMakeCache.txt
 
     elif [ "$TYPE" == "vs" ] ; then
         find ./ -name "*.o" -type f -delete
-        #architecture selection inspired int he tess formula, shouldn't build both architectures in the same run
         echo "building $TYPE | $ARCH | $VS_VER | vs: $VS_VER_GEN"
         echo "--------------------"
         GENERATOR_NAME="Visual Studio ${VS_VER_GEN}"     
-
         ZLIB_ROOT="$LIBS_ROOT/zlib/"
         ZLIB_INCLUDE_DIR="$LIBS_ROOT/zlib/include"
         ZLIB_LIBRARY="$LIBS_ROOT/zlib/lib/$TYPE/zlib.lib"   
@@ -169,13 +167,16 @@ function build() {
             -DBUILD_SHARED_LIBS=OFF \
             -DASSIMP_BUILD_TESTS=0 \
             -DASSIMP_BUILD_SAMPLES=0 \
-            -DASSIMP_BUILD_3MF_IMPORTER=0"
+            -DASSIMP_BUILD_3MF_IMPORTER=0 \
+            -DASSIMP_WARNINGS_AS_ERRORS=OFF"
 
         cmake .. ${DEFS} \
             -A "${PLATFORM}" \
             ${CMAKE_WIN_SDK} \
             -G "${GENERATOR_NAME}" \
             -DCMAKE_INSTALL_PREFIX=. \
+            -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${VS_C_FLAGS}" \
+            -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${VS_C_FLAGS}" \
             -DASSIMP_BUILD_ZLIB=OFF \
             -DZLIB_ROOT=${ZLIB_ROOT} \
             -DZLIB_INCLUDE_DIR=${ZLIB_INCLUDE_DIR} \

--- a/apothecary/formulas/fmod.sh
+++ b/apothecary/formulas/fmod.sh
@@ -25,7 +25,7 @@ function download() {
 
 	if [ "$TYPE" == "vs" ]; then
 		PKG=fmod_${TYPE}${ARCH}.tar.bz2
-		if [ "$ARCH" == "arm64" ] || [ "$ARCH" == "arm" ]; then
+		if [ "$ARCH" == "arm64" ] || [ "$ARCH" == "arm64ec" ] || [ "$ARCH" == "arm" ]; then
 			mkdir fmod
 			return 0;
 		fi
@@ -46,10 +46,8 @@ function prepare() {
 # executed inside the lib src dir
 function build() {
 
-	if [ "$ARCH" == "arm64" ] || [ "$ARCH" == "arm" ]; then
-		if [ "$ARCH" == "arm64" ]; then
-			return 0;
-		fi
+	if [ "$ARCH" == "arm64" ] || [ "$ARCH" == "arm64ec" ] || [ "$ARCH" == "arm" ]; then
+		return 0;
 	fi
 
 	if [ "$TYPE" == "osx" ]; then

--- a/apothecary/formulas/fmodex.sh
+++ b/apothecary/formulas/fmodex.sh
@@ -25,12 +25,11 @@ function download() {
 		mkdir fmodex
 		return;
 	fi
-	if [ "$ARCH" == "arm64" ] || [ "$ARCH" == "arm" ]; then
+	if [ "$ARCH" == "arm64" ] || [ "$ARCH" == "arm64ec" ] || [ "$ARCH" == "arm" ]; then
 		PKG=fmodex_${TYPE}${ARCH}.tar.bz2
-		if [ "$ARCH" == "arm64" ]; then
-			mkdir fmodex
-			return 0;
-		fi
+		mkdir fmodex
+		return 0;
+		
 	else
 		PKG=fmodex_${TYPE}.tar.bz2
 	fi
@@ -48,8 +47,8 @@ function prepare() {
 # executed inside the lib src dir
 function build() {
 
-	if [ "$ARCH" == "arm64" ] || [ "$ARCH" == "arm" ]; then
-		if [ "$ARCH" == "arm64" ]; then
+	if [ "$ARCH" == "arm64" ] || [ "$ARCH" == "arm64ec" ] || [ "$ARCH" == "arm" ]; then
+		if [ "$ARCH" == "arm64" ] || [ "$ARCH" == "arm64ec" ]; then
 			return 0;
 		fi
 	fi

--- a/apothecary/formulas/opencv/opencv.sh
+++ b/apothecary/formulas/opencv/opencv.sh
@@ -323,14 +323,7 @@ function build() {
         -DBUILD_WASM_INTRIN_TESTS=OFF \
         -DBUILD_WITH_STATIC_CRT=OFF \
         ${CMAKE_WIN_SDK}
-        
-
     cmake --build . --target install --config Release
-
-    # cmake -DCMAKE_BUILD_TYPE=Release --build . --config Release 
-
-    # cmake --build build --target install --config Release
-
     cd ..    
     
   elif [[ "$TYPE" == "ios" || "${TYPE}" == "tvos" ]] ; then
@@ -763,8 +756,6 @@ function build() {
       -DCMAKE_INCLUDE_OUTPUT_DIRECTORY=include \
       -DCMAKE_INSTALL_INCLUDEDIR=include
     cmake --build build --target install --config Release
-    # make 
-    # make install
   fi
 
 }
@@ -808,11 +799,16 @@ function copy() {
     mkdir -p $1/bin//$PLATFORM/Debug
     mkdir -p $1/bin/$PLATFORM/Release
 
-    cp -v "build_${TYPE}_${ARCH}/Release/${BUILD_PLATFORM}/vc${VS_VER}/lib/"*.lib $1/lib/$TYPE/$PLATFORM/Release
-    cp -v "build_${TYPE}_${ARCH}/Debug/${BUILD_PLATFORM}/vc${VS_VER}/lib/"*.lib $1/lib/$TYPE/$PLATFORM/Debug
+    OUTPUT_FOLDER=${BUILD_PLATFORM}
+    if [ "$ARCH" == "arm64ec" ]; then
+      OUTPUT_FOLDER=x64
+    fi
 
-    cp -v "build_${TYPE}_${ARCH}/Release/${BUILD_PLATFORM}/vc${VS_VER}/bin/"*.dll $1/bin/$PLATFORM/Release
-    cp -v "build_${TYPE}_${ARCH}/Debug/${BUILD_PLATFORM}/vc${VS_VER}/bin/"*.dll $1/bin/$PLATFORM/Debug
+    cp -v "build_${TYPE}_${ARCH}/Release/${OUTPUT_FOLDER}/vc${VS_VER}/lib/"*.lib $1/lib/$TYPE/$PLATFORM/Release
+    cp -v "build_${TYPE}_${ARCH}/Debug/${OUTPUT_FOLDER}/vc${VS_VER}/lib/"*.lib $1/lib/$TYPE/$PLATFORM/Debug
+
+    cp -v "build_${TYPE}_${ARCH}/Release/${OUTPUT_FOLDER}/vc${VS_VER}/bin/"*.dll $1/bin/$PLATFORM/Release
+    cp -v "build_${TYPE}_${ARCH}/Debug/${OUTPUT_FOLDER}/vc${VS_VER}/bin/"*.dll $1/bin/$PLATFORM/Debug
 
     cp -v "build_${TYPE}_${ARCH}/3rdparty/lib/Release/"*.lib $1/lib/$TYPE/$PLATFORM/Release
     cp -v "build_${TYPE}_${ARCH}/3rdparty/lib/Debug/"*.lib $1/lib/$TYPE/$PLATFORM/Debug

--- a/apothecary/formulas/pugixml.sh
+++ b/apothecary/formulas/pugixml.sh
@@ -53,29 +53,43 @@ function build() {
         ZLIB_INCLUDE_DIR="$LIBS_ROOT/zlib/include"
         ZLIB_LIBRARY="$LIBS_ROOT/zlib/lib/$TYPE/$PLATFORM/zlib.lib"
 
-
         DEFS="-DLIBRARY_SUFFIX=${ARCH} \
-            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_STANDARD=17 \
             -DCMAKE_CXX_STANDARD=17 \
             -DCMAKE_CXX_STANDARD_REQUIRED=ON \
             -DCMAKE_CXX_EXTENSIONS=OFF
             -DBUILD_SHARED_LIBS=OFF \
-            -DCMAKE_INSTALL_PREFIX=Release \
             -DCMAKE_INCLUDE_OUTPUT_DIRECTORY=include \
             -DCMAKE_INSTALL_INCLUDEDIR=include \
             -DCMAKE_INSTALL_LIBDIR=lib"        
      
         cmake .. ${DEFS} \
-            -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1" \
-            -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1" \
+            -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${FLAGS_RELEASE} ${VS_C_FLAGS}" \
+            -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${FLAGS_RELEASE} ${VS_C_FLAGS}" \
             -DSTATIC_CRT=OFF \
             -DBUILD_TESTS=OFF \
+            -DCMAKE_INSTALL_PREFIX=Release \
             ${CMAKE_WIN_SDK} \
+            -DCMAKE_BUILD_TYPE=Release \
             -A "${PLATFORM}" \
             -G "${GENERATOR_NAME}"
 
         cmake --build . --config Release --target install
+
+        cmake .. ${DEFS} \
+            -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${FLAGS_DEBUG} ${VS_C_FLAGS}" \
+            -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${FLAGS_DEBUG} ${VS_C_FLAGS}" \
+            -DSTATIC_CRT=OFF \
+            -DBUILD_TESTS=OFF \
+            ${CMAKE_WIN_SDK} \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_INSTALL_PREFIX=Debug \
+            -A "${PLATFORM}" \
+            -G "${GENERATOR_NAME}"
+
+         cmake --build . --config Debug --target install
+
+         cd ..
 
 	elif [ "$TYPE" == "android" ]; then
         source ../../android_configure.sh $ABI make
@@ -148,6 +162,7 @@ function copy() {
         mkdir -p $1/lib/$TYPE/$PLATFORM/
 		cp -Rv "build_${TYPE}_${ARCH}/Release/include/" $1/ 
         cp -f "build_${TYPE}_${ARCH}/Release/lib/pugixml.lib" $1/lib/$TYPE/$PLATFORM/pugixml.lib
+        cp -f "build_${TYPE}_${ARCH}/Debug/lib/pugixml.lib" $1/lib/$TYPE/$PLATFORM/pugixmlD.lib
 	elif [ "$TYPE" == "osx" ] || [ "$TYPE" == "ios" ] || [ "$TYPE" == "tvos" ]; then
 		# copy lib
 		cp -Rv libpugixml.a $1/lib/$TYPE/pugixml.a

--- a/apothecary/formulas/rtAudio/rtAudio.sh
+++ b/apothecary/formulas/rtAudio/rtAudio.sh
@@ -109,17 +109,18 @@ function build() {
         -DCMAKE_CXX_STANDARD=17 \
         -DCMAKE_CXX_STANDARD_REQUIRED=ON \
         -DCMAKE_CXX_EXTENSIONS=OFF
-        -DBUILD_SHARED_LIBS=OFF \
+        -DBUILD_SHARED_LIBS=ON \
         -DCMAKE_INCLUDE_OUTPUT_DIRECTORY=include \
         -DCMAKE_INSTALL_INCLUDEDIR=include \
         -DAUDIO_WINDOWS_WASAPI=ON \
         -DAUDIO_WINDOWS_DS=ON \
         -DAUDIO_WINDOWS_ASIO=ON \
-        -DBUILD_WITH_STATIC_CRT=OFF 
+        -DBUILD_WITH_STATIC_CRT=OFF \
+        -DRTAUDIO_STATIC_MSVCRT=OFF
         "         
     cmake .. ${DEFS} \
-        -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${FLAGS_RELEASE} ${VS_C_FLAGS} ${EXCEPTION_FLAGS}" \
-        -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${FLAGS_RELEASE} ${VS_C_FLAGS} ${EXCEPTION_FLAGS}" \
+        -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${FLAGS_RELEASE} ${EXCEPTION_FLAGS}" \
+        -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${FLAGS_RELEASE}  ${EXCEPTION_FLAGS}" \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_LIBDIR="lib" \
         -DCMAKE_INSTALL_PREFIX=Release \
@@ -131,8 +132,8 @@ function build() {
     cmake --build . --config Release --target install
 
     cmake .. ${DEFS} \
-        -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${FLAGS_DEBUG} ${VS_C_FLAGS} ${EXCEPTION_FLAGS}" \
-        -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1  ${FLAGS_DEBUG} ${VS_C_FLAGS} ${EXCEPTION_FLAGS}" \
+        -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${FLAGS_DEBUG}  ${EXCEPTION_FLAGS}" \
+        -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1  ${FLAGS_DEBUG} ${EXCEPTION_FLAGS}" \
         -DCMAKE_BUILD_TYPE=Debug \
         -DCMAKE_INSTALL_LIBDIR="lib" \
         -DCMAKE_INSTALL_PREFIX=Debug \
@@ -173,9 +174,16 @@ function copy() {
 	mkdir -p $1/lib/$TYPE
 	if [ "$TYPE" == "vs" ] ; then
 		mkdir -p $1/lib/$TYPE/$PLATFORM/
+		mkdir -p $1/bin/$TYPE/$PLATFORM/
+
 		cp -Rv build_${TYPE}_${ARCH}/Release/include/rtaudio/* $1/include/
+
     	cp -vf "build_${TYPE}_${ARCH}/Release/lib/rtaudio.lib" $1/lib/$TYPE/$PLATFORM/rtaudio.lib
     	cp -vf "build_${TYPE}_${ARCH}/Debug/lib/rtaudiod.lib" $1/lib/$TYPE/$PLATFORM/rtaudioD.lib
+
+    	cp -vf "build_${TYPE}_${ARCH}/Release/bin/rtaudio.dll" $1/bin/$TYPE/$PLATFORM/rtaudio.dll
+    	cp -vf "build_${TYPE}_${ARCH}/Debug/bin/rtaudiod.dll" $1/bin/$TYPE/$PLATFORM/rtaudioD.dll
+
 	elif [ "$TYPE" == "msys2" ] ; then
 		cd build
 		ls

--- a/apothecary/formulas/rtAudio/rtAudio.sh
+++ b/apothecary/formulas/rtAudio/rtAudio.sh
@@ -118,16 +118,29 @@ function build() {
         -DBUILD_WITH_STATIC_CRT=OFF 
         "         
     cmake .. ${DEFS} \
-        -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1" \
-        -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1" \
+        -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${FLAGS_RELEASE} ${VS_C_FLAGS} ${EXCEPTION_FLAGS}" \
+        -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${FLAGS_RELEASE} ${VS_C_FLAGS} ${EXCEPTION_FLAGS}" \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_LIBDIR="lib" \
         -DCMAKE_INSTALL_PREFIX=Release \
         ${CMAKE_WIN_SDK} \
+        ${FLAGS_RELEASE} \
         -A "${PLATFORM}" \
         -G "${GENERATOR_NAME}"
 
     cmake --build . --config Release --target install
+
+    cmake .. ${DEFS} \
+        -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${FLAGS_DEBUG} ${VS_C_FLAGS} ${EXCEPTION_FLAGS}" \
+        -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1  ${FLAGS_DEBUG} ${VS_C_FLAGS} ${EXCEPTION_FLAGS}" \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_INSTALL_LIBDIR="lib" \
+        -DCMAKE_INSTALL_PREFIX=Debug \
+        ${CMAKE_WIN_SDK} \
+        ${FLAGS_RELEASE} \
+        -A "${PLATFORM}" \
+        -G "${GENERATOR_NAME}"
+
     cmake --build . --config Debug --target install
 
     cd ..
@@ -162,7 +175,7 @@ function copy() {
 		mkdir -p $1/lib/$TYPE/$PLATFORM/
 		cp -Rv build_${TYPE}_${ARCH}/Release/include/rtaudio/* $1/include/
     	cp -vf "build_${TYPE}_${ARCH}/Release/lib/rtaudio.lib" $1/lib/$TYPE/$PLATFORM/rtaudio.lib
-    	cp -vf "build_${TYPE}_${ARCH}/Release/lib/rtaudiod.lib" $1/lib/$TYPE/$PLATFORM/rtaudioD.lib
+    	cp -vf "build_${TYPE}_${ARCH}/Debug/lib/rtaudiod.lib" $1/lib/$TYPE/$PLATFORM/rtaudioD.lib
 	elif [ "$TYPE" == "msys2" ] ; then
 		cd build
 		ls

--- a/scripts/load.sh
+++ b/scripts/load.sh
@@ -8,7 +8,7 @@
 function loadsave() {
 
   if [ -z "$2" ]; then
-    echo "Load function not implemented - Param error"
+    #echo "Load function not implemented - Param error"
     return 1
   fi
 

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -8,15 +8,13 @@
 function savestatus {
 
     if [ -z "$2" ]; then
-        echo "Save function not implemented - Param error"
+        #echo "Save function not implemented - Param error"
         return 1
     fi
-
-
     # Check if the save file exists
     #SAVE_FILE="$SCRIPT_DIR/build_status.txt"
     LOCAL_SAVE_FILE="$6"
-    echo "save file: "${LOCAL_SAVE_FILE}" 0:$0 1:$1 2:$2 3:$3 4:$4 5:$5 6:$6"
+    #echoVerboe "save file: "${LOCAL_SAVE_FILE}" 0:$0 1:$1 2:$2 3:$3 4:$4 5:$5 6:$6"
     if [ ! -f "${LOCAL_SAVE_FILE}" ]; then
         touch "${LOCAL_SAVE_FILE}"
         echo "=======" >> "${LOCAL_SAVE_FILE}"

--- a/scripts/simd.sh
+++ b/scripts/simd.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# this is to search for instrinct code that may not be availble in arm devices and needs checking 
+# pass a variable to this for another location 
+
+# Default directory to search
+DEFAULT_SEARCH_DIR="../apothecary/apothecary/build"
+
+# use the first command-line argument is the search directory, or use the default
+SEARCH_DIR="${1:-$DEFAULT_SEARCH_DIR}"
+
+# file to save the results (optional)
+LOG_FILE=""
+
+# headers associated with SIMD / Instrintics 
+SIMD_HEADERS=("xmmintrin.h" "emmintrin.h" "immintrin.h" "arm_neon.h" "arm64_neon.h")
+
+# Function to search for SIMD headers
+search_simd() {
+    for header in "${SIMD_HEADERS[@]}"; do
+        echo "Searching for $header in $SEARCH_DIR"
+        if [ -n "$LOG_FILE" ]; then
+            grep -rnw "$SEARCH_DIR" -e "#include.*$header" >> "$LOG_FILE"
+        else
+            grep -rnw "$SEARCH_DIR" -e "#include.*$header"
+        fi
+    done
+    echo "Finished"
+}
+
+# Check for logging option
+if [ "$2" == "--log" ]; then
+    LOG_FILE="simd_search_results.txt"
+    echo "Logging results to $LOG_FILE"
+    # Clear the log file
+    > "$LOG_FILE"
+fi
+
+# Call the search function
+search_simd


### PR DESCRIPTION
- Fixed most linking CRT issue for x64. (rtAudio, assimp, opencv) = dynamic with debug/release 
- Modified Apothecary with more variables for VS building
- Added ARM64EC support + working - cmake all targets - targets Windows 11 automatically
- Global VS variables (c++ exception handler / settings) 
- Added variables to build variants for MSVC / LLVM (clang) 
