### PR TITLE
XCFramework Headers for all libraries

### DIFF
--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -1373,7 +1373,7 @@ function frameworkFormula() {
             ["OS64"]="OS64"
             ["WATCHOS"]="WATCHOS"
             ["VISIONOS"]="VISIONOS" # And again, for VISIONOS
-            ["SIMULATOR_VISIONOS"]="SIMULATOR64_VISIONOS"
+            ["SIMULATOR64_VISIONOS"]="SIMULATOR_VISIONOS"
         )
         # this gets a bit advanced bash so need Bash 4 - brew install bash if issues arrise... hectic problems 
         declare -a merged_dirs=()
@@ -1415,6 +1415,7 @@ function frameworkFormula() {
                             merged_dirs+=("$PATH_MERGE")
                         fi
                     else
+                        PATH_MERGE=$LIBS_DIR_REAL/$1/lib/$TYPE/${ARCH}/
                         MERGED_PATH="$LIBS_DIR_REAL/$1/lib/$TYPE/${ARCH}/$(basename "$ARCH_FILE" .a).a"
                         xcrun codesign --sign - $MERGED_PATH || true
                         if [[ "$num_archive_paths" -gt 1 ]]; then
@@ -1527,7 +1528,7 @@ function xframeworkFormula() {
             ["OS64"]="OS64"
             ["WATCHOS"]="WATCHOS"
             ["VISIONOS"]="VISIONOS" # And again, for VISIONOS
-            ["SIMULATOR_VISIONOS"]="SIMULATOR_VISIONOS"
+            ["SIMULATOR64_VISIONOS"]="SIMULATOR_VISIONOS"
         )
         # this gets a bit advanced bash so need Bash 4 - brew install bash if issues arrise... hectic problems
         declare -a merged_dirs=()
@@ -1595,7 +1596,7 @@ function xframeworkFormula() {
                                     echo "path_found_in_array == true"
                                 fi
                             else
-
+                                PATH_MERGE=$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/${ARCH}/
                                 MERGED_PATH="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/${ARCH}/$(basename "$ARCH_FILE" .a).a"
                                 echo "MERGED_PATH: $ARCH - $MERGED_PATH"
                                 xcrun codesign --sign - $MERGED_PATH || true

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -52,7 +52,7 @@ if [ -z "${TYPE+x}" ]; then
     echo "No TYPE argument provided."
     TYPE=
 else
-    echo "Argument TYPE 1: $TYPE"
+    echo "TYPE : $TYPE"
 fi
 ARCH=64 # library build arch, 32 or 64 bit (not used for some build types)
 

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -1369,11 +1369,11 @@ function frameworkFormula() {
             ["SIMULATOR_TVOS"]="SIMULATORARM64_TVOS"
             ["TVOS"]="TVOS" # Note: If TVOS doesn't have a pair, it's listed for consistency
             ["WATCHOS"]="WATCHOS" # Same note as TVOS
-            ["SIMULATOR_VISIONOS"]="SIMULATOR64_VISIONOS"
+            ["SIMULATOR_WATCHOS"]="SIMULATOR_WATCHOS"
             ["OS64"]="OS64"
             ["WATCHOS"]="WATCHOS"
-            ["VISIONOS"]="SIMULATOR64_VISIONOS" # And again, for VISIONOS
-            ["SIMULATOR_VISIONOS"]="SIMULATOR_VISIONOS"
+            ["VISIONOS"]="VISIONOS" # And again, for VISIONOS
+            ["SIMULATOR_VISIONOS"]="SIMULATOR64_VISIONOS"
         )
         # this gets a bit advanced bash so need Bash 4 - brew install bash if issues arrise... hectic problems 
         declare -a merged_dirs=()
@@ -1400,6 +1400,7 @@ function frameworkFormula() {
                         # Determine the output filename in the merged directory
                         PATH_MERGE=$LIBS_DIR_REAL/$1/lib/$TYPE/${ARCH}_${PAIR}/
                         MERGED_PATH="$LIBS_DIR_REAL/$1/lib/$TYPE/${ARCH}_${PAIR}/$(basename "$ARCH_FILE" .a).a"
+                        file $ARCH_FILE
                         # Use lipo to merge the architectures into a single file - prevents linking errors
                         xcrun lipo -create "$ARCH_FILE" "$PAIR_FILE" -output "$MERGED_PATH"
                         # echo "Merged $ARCH_FILE and $PAIR_FILE into $MERGED_PATH"
@@ -1522,10 +1523,10 @@ function xframeworkFormula() {
             ["SIMULATOR_TVOS"]="SIMULATORARM64_TVOS"
             ["TVOS"]="TVOS" # Note: If TVOS doesn't have a pair, it's listed for consistency
             ["WATCHOS"]="WATCHOS" # Same note as TVOS
-            ["SIMULATOR_VISIONOS"]="SIMULATOR64_VISIONOS"
+            ["SIMULATOR_WATCHOS"]="SIMULATOR_WATCHOS"
             ["OS64"]="OS64"
             ["WATCHOS"]="WATCHOS"
-            ["VISIONOS"]="SIMULATOR64_VISIONOS" # And again, for VISIONOS
+            ["VISIONOS"]="VISIONOS" # And again, for VISIONOS
             ["SIMULATOR_VISIONOS"]="SIMULATOR_VISIONOS"
         )
         # this gets a bit advanced bash so need Bash 4 - brew install bash if issues arrise... hectic problems
@@ -1662,15 +1663,17 @@ function xframeworkFormula() {
         
         cd $HERE_DIR
 
-        xcframework_path="${LIBS_DIR_REAL}/${1}/lib/${TYPE}/$1.xcframework"
+        XCFRAMEWORK_PATH="${LIBS_DIR_REAL}/${1}/lib/${TYPE}/$1.xcframework"
         # Loop over each .a file found within the xcframework
-        find "$xcframework_path" -type f -name "*.a" | while read -r lib_a; do
+        find "$XCFRAMEWORK_PATH" -type f -name "*.a" | while read -r lib_a; do
             echo "Securing $lib_a..."
             lipo -info "$lib_a"
             xcrun codesign --sign - "$lib_a" || true
              . "$SECURE_SCRIPT"
             secure "$lib_a" "$VERSION" "$DEFINES"
         done
+
+        # codesign --timestamp -s  $XCFRAMEWORK_PATH
 
         for PLATFORM in "${PLATFORM_TYPES[@]}"; do
             PLATFORM_DIR="${LIBS_DIR_REAL}/${1}/lib/$PLATFORM"

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -1429,6 +1429,7 @@ function frameworkFormula() {
                         else
                             if [[ ! "$xcframework_flags" =~ "$MERGED_PATH" ]]; then
                                 xcframework_flags+=" -library $MERGED_PATH"
+                                xcframework_flags+=" -headers $LIBS_DIR_REAL/$1/include"
                             fi
                         fi
                     fi
@@ -1450,14 +1451,16 @@ function frameworkFormula() {
                 xcrun codesign --sign - "${dir}/lib${1}_combined.a" || true
                 if [[ ! "$xcframework_flags" =~ "${dir}/lib${1}_combined.a" ]]; then
                     xcframework_flags+=" -library ${dir}/lib${1}_combined.a"
+                    xcframework_flags+=" -headers $LIBS_DIR_REAL/$1/include"
                 fi
             else
                 # Directly use the single archive or skip if none
                 xcframework_flags+=" -library ${a_files[0]}"
+                xcframework_flags+=" -headers $LIBS_DIR_REAL/$1/include"
             fi
         done
 
-        xcframework_flags+=" -headers $LIBS_DIR_REAL/$1/include"
+        
 
         echoSuccess " flags: \"$1\" \"$xcframework_flags\" "
         HERE_DIR=$(cd $(dirname "./"); pwd -P)
@@ -1611,6 +1614,7 @@ function xframeworkFormula() {
                                 else
                                     if [[ ! "$xcframework_flags" =~ "$MERGED_PATH" ]]; then
                                         xcframework_flags+=" -library $MERGED_PATH"
+                                        xcframework_flags+=" -headers $LIBS_DIR_REAL/$1/include"
                                         echo "xcframework_flags: adding -library $MERGED_PATH"
                                     else
                                         echo "xcframework_flags: not adding already in full flags: $xcframework_flags"
@@ -1640,14 +1644,14 @@ function xframeworkFormula() {
                 xcrun codesign --sign - "${dir}/lib${1}_combined.a" || true
                 if [[ ! "$xcframework_flags" =~ "${dir}/lib${1}_combined.a" ]]; then
                     xcframework_flags+=" -library ${dir}/lib${1}_combined.a"
+                    xcframework_flags+=" -headers $LIBS_DIR_REAL/$1/include"
                 fi
             else
                 # Directly use the single archive or skip if none
                 xcframework_flags+=" -library ${a_files[0]}"
+                xcframework_flags+=" -headers $LIBS_DIR_REAL/$1/include"
              fi
         done
-
-        xcframework_flags+=" -headers $LIBS_DIR_REAL/$1/include"
 
         echoSuccess " flags: \"$1\" \"$xcframework_flags\" "
         HERE_DIR=$(cd $(dirname "./"); pwd -P)

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -98,8 +98,8 @@ if [ "$(${APOTHECARY_DIR}/ostype.sh)" == "osx" ]; then
     # used when building for ios, the sdks you have installed are found in:
     # $XCODE_DEV_ROOT/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator#.#.sdk
     IOS_LATEST_SDK="xcrun -sdk iphoneos --show-sdk-version" # stupid hack to keep my syntax highlighting from breaking :P
-    IOS_SDK_VER=16.0
-    IOS_MIN_SDK_VER=13.0
+    IOS_SDK_VER=17.0
+    IOS_MIN_SDK_VER=15.0
 
 if ! which realpath >&/dev/null; then
   if ! which brew >&/dev/null; then

--- a/apothecary/formulas/curl/curl.sh
+++ b/apothecary/formulas/curl/curl.sh
@@ -337,7 +337,7 @@ function copy() {
         secure $1/lib/$TYPE/$PLATFORM/libcurl.lib       
 	elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos)$ ]]; then
         mkdir -p $1/lib/$TYPE/$PLATFORM/
-		cp -Rv "build_${TYPE}_${PLATFORM}/Release/include/" $1/ 
+		cp -Rv "build_${TYPE}_${PLATFORM}/Release/include/" $1/include
         cp -v "build_${TYPE}_${PLATFORM}/Release/lib/libcurl.a" $1/lib/$TYPE/$PLATFORM/curl.a
         . "$SECURE_SCRIPT"
         secure $1/lib/$TYPE/$PLATFORM/curl.a

--- a/apothecary/formulas/curl/curl.sh
+++ b/apothecary/formulas/curl/curl.sh
@@ -228,10 +228,13 @@ function build() {
         ZLIB_LIBRARY="$LIBS_ROOT/zlib/lib/$TYPE/$PLATFORM/zlib.a"
 
         PATH="${PATH};${OPENSSL_PATH}/lib/${TYPE}/${PLATFORM};${ZLIB_LIBRARY}/lib/${TYPE}/${PLATFORM}"
+
+        rm -f ${OPENSSL_PATH}/lib/libssl.a || true
+        rm -f ${OPENSSL_PATH}/lib/libcrypto.a || true
+        rm -f ${ZLIB_ROOT}/lib/zlib.a || true
          
         cp ${OPENSSL_PATH}/lib/${TYPE}/${PLATFORM}/libssl.a ${OPENSSL_PATH}/lib/libssl.a # this works! 
         cp ${OPENSSL_PATH}/lib/${TYPE}/${PLATFORM}/libcrypto.a ${OPENSSL_PATH}/lib/libcrypto.a
-
         cp ${ZLIB_LIBRARY} ${ZLIB_ROOT}/lib/zlib.a
 
 

--- a/apothecary/formulas/freetype/freetype.sh
+++ b/apothecary/formulas/freetype/freetype.sh
@@ -360,14 +360,10 @@ function copy() {
 
 	# copy headers
 	mkdir -p $1/include/freetype2/
-
-	# copy files from the build root
-	cp -R include/* $1/include/freetype2/
-
 	mkdir -p $1/lib/$TYPE
 	if [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos)$ ]]; then
 		mkdir -p $1/lib/$TYPE/$PLATFORM/
-		cp -R "build_${TYPE}_${PLATFORM}/Release/include" $1/include
+		cp -R "build_${TYPE}_${PLATFORM}/Release/include/" $1/include
 		cp -v "build_${TYPE}_${PLATFORM}/Release/lib/libfreetype.a" $1/lib/$TYPE/$PLATFORM/libfreetype.a
 		. "$SECURE_SCRIPT"
 		secure $1/lib/$TYPE/$PLATFORM/libfreetype.a
@@ -381,14 +377,17 @@ function copy() {
 
 	elif [ "$TYPE" == "msys2" ] ; then
 		# cp -v lib/$TYPE/libfreetype.a $1/lib/$TYPE/libfreetype.a
+		cp -R include/* $1/include/freetype2/
 		echoWarning "TODO: copy msys2 lib"
 	elif [ "$TYPE" == "android" ] ; then
 	    rm -rf $1/lib/$TYPE/$ABI
         mkdir -p $1/lib/$TYPE/$ABI
+        cp -R include/* $1/include/freetype2/
 	    cp -v build_$ABI/libfreetype.a $1/lib/$TYPE/$ABI/libfreetype.a
 	    . "$SECURE_SCRIPT"
 		secure $1/lib/$TYPE/$ABI/libfreetype.a
 	elif [ "$TYPE" == "emscripten" ] ; then
+		cp -R include/* $1/include/freetype2/
 		cp -v "build_${TYPE}/freetype_wasm.wasm" $1/lib/$TYPE/libfreetype.wasm
 		. "$SECURE_SCRIPT"
 		secure $1/lib/$TYPE/libfreetype.wasm

--- a/apothecary/toolchains/ios.toolchain.cmake
+++ b/apothecary/toolchains/ios.toolchain.cmake
@@ -262,10 +262,10 @@ if(NOT DEFINED DEPLOYMENT_TARGET)
     set(DEPLOYMENT_TARGET "6.0")
   elseif(PLATFORM STREQUAL "MAC")
     # Unless specified, SDK version 10.13 (High Sierra) is used by default as the minimum target version (macos).
-    set(DEPLOYMENT_TARGET "11.0")
+    set(DEPLOYMENT_TARGET "10.15")
   elseif(PLATFORM STREQUAL "VISIONOS" OR PLATFORM STREQUAL "SIMULATOR_VISIONOS" OR PLATFORM STREQUAL "SIMULATOR64_VISIONOS")
     # Unless specified, SDK version 1.0 is used by default as minimum target version (visionOS).
-    set(DEPLOYMENT_TARGET "1.0")
+    set(DEPLOYMENT_TARGET "1.1")
   elseif(PLATFORM STREQUAL "MAC_ARM64")
     # Unless specified, SDK version 11.0 (Big Sur) is used by default as the minimum target version (macOS on arm).
     set(DEPLOYMENT_TARGET "11.0")
@@ -274,10 +274,10 @@ if(NOT DEFINED DEPLOYMENT_TARGET)
     set(DEPLOYMENT_TARGET "11.0")
   elseif(PLATFORM STREQUAL "MAC_CATALYST" OR PLATFORM STREQUAL "MAC_CATALYST_ARM64")
     # Unless specified, SDK version 13.0 is used by default as the minimum target version (mac catalyst minimum requirement).
-    set(DEPLOYMENT_TARGET "13.1")
+    set(DEPLOYMENT_TARGET "15.0")
   else()
     # Unless specified, SDK version 11.0 is used by default as the minimum target version (iOS, tvOS).
-    set(DEPLOYMENT_TARGET "13.0")
+    set(DEPLOYMENT_TARGET "15.0")
   endif()
   message(STATUS "[DEFAULTS] Using the default min-version since DEPLOYMENT_TARGET not provided!")
 elseif(DEFINED DEPLOYMENT_TARGET AND PLATFORM MATCHES "^MAC_CATALYST" AND ${DEPLOYMENT_TARGET} VERSION_LESS "13.1")


### PR DESCRIPTION
This is currently working fine without this as we are defining header location separately.

However with this change, no headers are needed to be included, it's automatic for each platform, and headers are separated with whatever custom changes are applied per platform also, like define settings etc. 

When using mega xcframework this, while some duplicated header files are pushed into files, is the recommended approach. 