### PR TITLE
Bleeding - GitHub Actions 

### DIFF
--- a/.github/workflows/build-catos.yml
+++ b/.github/workflows/build-catos.yml
@@ -84,19 +84,19 @@ jobs:
           TARGET: "catos"
           BUNDLE: ${{ matrix.bundle }}
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
-      - name: Package
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        working-directory: ${{ env.GITHUB_WORKSPACE }}
-        run: scripts/package.sh
-        env:
-          BUNDLE: ${{ matrix.bundle }}
-          GA_CI_SECRET: ${{ secrets.CI_SECRET }}
-      - name: Update Release XCFramework
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: johnwbyrd/update-release@v1.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.release }}
-          release: ${{ env.release }}
-          prerelease: ${{ env.prerelease }}
-          files: out/openFrameworksLibs_${{ env.release }}_${{ env.TARGET }}_${{ matrix.bundle }}.tar.bz2
+#      - name: Package
+#        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+#        working-directory: ${{ env.GITHUB_WORKSPACE }}
+#        run: scripts/package.sh
+#        env:
+#          BUNDLE: ${{ matrix.bundle }}
+#          GA_CI_SECRET: ${{ secrets.CI_SECRET }}
+#      - name: Update Release XCFramework
+#        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+#        uses: johnwbyrd/update-release@v1.0.0
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          tag: ${{ env.release }}
+#          release: ${{ env.release }}
+#          prerelease: ${{ env.prerelease }}
+#          files: out/openFrameworksLibs_${{ env.release }}_${{ env.TARGET }}_${{ matrix.bundle }}.tar.bz2

--- a/.github/workflows/build-watchos.yml
+++ b/.github/workflows/build-watchos.yml
@@ -92,19 +92,19 @@ jobs:
           TARGET: "watchos"
           BUNDLE: ${{ matrix.bundle }}
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
-      - name: Package
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        working-directory: ${{ env.GITHUB_WORKSPACE }}
-        run: scripts/package.sh
-        env:
-          BUNDLE: ${{ matrix.bundle }}
-          GA_CI_SECRET: ${{ secrets.CI_SECRET }}
-      - name: Update Release XCFramework
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: johnwbyrd/update-release@v1.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.release }}
-          release: ${{ env.release }}
-          prerelease: ${{ env.prerelease }}
-          files: out/openFrameworksLibs_${{ env.release }}_${{ env.TARGET }}_${{ matrix.bundle }}.tar.bz2
+#      - name: Package
+#        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+#        working-directory: ${{ env.GITHUB_WORKSPACE }}
+#        run: scripts/package.sh
+#        env:
+#          BUNDLE: ${{ matrix.bundle }}
+#          GA_CI_SECRET: ${{ secrets.CI_SECRET }}
+#      - name: Update Release XCFramework
+#        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+#        uses: johnwbyrd/update-release@v1.0.0
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          tag: ${{ env.release }}
+#          release: ${{ env.release }}
+#          prerelease: ${{ env.prerelease }}
+#          files: out/openFrameworksLibs_${{ env.release }}_${{ env.TARGET }}_${{ matrix.bundle }}.tar.bz2

--- a/.github/workflows/build-xros.yml
+++ b/.github/workflows/build-xros.yml
@@ -55,14 +55,14 @@ jobs:
           BUNDLE: ${{ matrix.bundle }}
           ARCH: x86_64
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
-      # - name: Build VisionOS SIMULATOR arm64
-      #   working-directory: ${{ env.GITHUB_WORKSPACE }}
-      #   run: scripts/build.sh
-      #   env:
-      #     TARGET: "xros"
-      #     BUNDLE: ${{ matrix.bundle }}
-      #     ARCH: SIM_arm64
-      #     GA_CI_SECRET: ${{ secrets.CI_SECRET }}
+      - name: Build VisionOS SIMULATOR arm64
+        working-directory: ${{ env.GITHUB_WORKSPACE }}
+        run: scripts/build.sh
+        env:
+          TARGET: "xros"
+          BUNDLE: ${{ matrix.bundle }}
+          ARCH: SIM_arm64
+          GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Package Binaries for Artifact
         if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         working-directory: ${{ env.GITHUB_WORKSPACE }}
@@ -91,19 +91,19 @@ jobs:
         env:
           BUNDLE: ${{ matrix.bundle }}
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
-      - name: Package
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        working-directory: ${{ env.GITHUB_WORKSPACE }}
-        run: scripts/package.sh
-        env:
-          BUNDLE: ${{ matrix.bundle }}
-          GA_CI_SECRET: ${{ secrets.CI_SECRET }}
-      - name: Update Release XCFramework
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: johnwbyrd/update-release@v1.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.release }}
-          release: ${{ env.release }}
-          prerelease: ${{ env.prerelease }}
-          files: out/openFrameworksLibs_${{ env.release }}_${{ env.TARGET }}_${{ matrix.bundle }}.tar.bz2
+#      - name: Package
+#        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+#        working-directory: ${{ env.GITHUB_WORKSPACE }}
+#        run: scripts/package.sh
+#        env:
+#          BUNDLE: ${{ matrix.bundle }}
+#          GA_CI_SECRET: ${{ secrets.CI_SECRET }}
+#      - name: Update Release XCFramework
+#        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+#        uses: johnwbyrd/update-release@v1.0.0
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          tag: ${{ env.release }}
+#          release: ${{ env.release }}
+#          prerelease: ${{ env.prerelease }}
+#          files: out/openFrameworksLibs_${{ env.release }}_${{ env.TARGET }}_${{ matrix.bundle }}.tar.bz2


### PR DESCRIPTION
Disable Actions Upload of Seperate XCFrameworks /Libs for extra and new VisionOS/CatOS/WatchOS.

The seperate uploads are not needed anymore as super mega xcframework handles them. 

This should save some space and time 