### PR TITLE
Apothecary xcframeworks build fix 

### DIFF
--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -1425,6 +1425,11 @@ function cleanFormula() {
 function frameworkFormula() {
 
     export LIBS_DIR_REAL=$(realpath $LIBS_DIR)
+    XLIBSLOCAL="$LIBS_DIR/../xout"
+    if [[  ! -e "$XLIBSLOCAL/$1/lib/$TYPE" ]] && [[ $TYPE == "macos" ]]; then
+        mkdir -p $XLIBSLOCAL/$1/lib/$TYPE
+    fi
+    export XLIBS_DIR_REAL=$(realpath $XLIBSLOCAL)
     if [ ! -e "$LIBS_DIR/$1" ] ; then
         echoVerbose " Nothing to create framework from to merge in lib dest dir: \"$1\""
     else
@@ -1471,7 +1476,7 @@ function frameworkFormula() {
                     DIR_PATH="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/$ARCH/"
                     if [ -d "$DIR_PATH" ]; then
                         echo "Processing ARCH: $ARCH"
-                        MERGED_DIR="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/${ARCH}_${PAIR}"
+                        MERGED_DIR="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/MERGE_${ARCH}_${PAIR}"
                         declare -a archive_paths=()
                         while IFS= read -r -d $'\0' file; do
                             archive_paths+=("$file")
@@ -1511,8 +1516,15 @@ function frameworkFormula() {
                                 mkdir -p "$MERGED_DIR"
                                 echo "MERGED_DIR: $ARCH - Pair: $PAIR"
                                 # Determine the output filename in the merged directory
-                                PATH_MERGE=$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/${ARCH}_${PAIR}/
-                                MERGED_PATH="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/${ARCH}_${PAIR}/$(basename "$ARCH_FILE" .a).a"
+                                PATH_MERGE=$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/MERGE_${ARCH}_${PAIR}/
+                                MERGED_PATH="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/MERGE_${ARCH}_${PAIR}/$(basename "$ARCH_FILE" .a).a"
+                                mkdir -p "$PATH_MERGE"
+                                echo "MERGED_PATH: $ARCH - $MERGED_PATH"
+                                if ! command -v rsync &> /dev/null; then    
+                                    rsync -av --include --delete '*/' --include '*.a' --exclude '*' "$DIR_PATH/" "$PATH_MERGE/"
+                                else
+                                    cp -v "$DIR_PATH"/*.a "$PATH_MERGE"
+                                fi
                                 # Use lipo to merge the architectures into a single file - prevents linking errors
                                 xcrun lipo -create "$ARCH_FILE" "$PAIR_FILE" -output "$MERGED_PATH"
                                 echo "Merged $ARCH_FILE and $PAIR_FILE into $MERGED_PATH"
@@ -1530,9 +1542,10 @@ function frameworkFormula() {
                                     echoVerbose "path_found_in_array == true"
                                 fi
                             else
-                                PATH_MERGE=$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/${ARCH}/
-                                MERGED_PATH="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/${ARCH}/$(basename "$ARCH_FILE" .a).a"
-                                echo "MERGED_PATH: $ARCH - $MERGED_PATH"
+                                PATH_MERGE=$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/MERGE_${ARCH}/
+                                MERGED_PATH="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/MERGE_${ARCH}/$(basename "$ARCH_FILE" .a).a"
+                                echo "MERGED_PATH: $ARCH - $MERGED_PATH
+                                mkdir -p "$PATH_MERGE""
                                 xcrun codesign --sign - $MERGED_PATH || true
                                 if [[ "$num_archive_paths" -gt 1 ]]; then
                                     for dir in "${merged_dirs[@]}"; do
@@ -1597,17 +1610,48 @@ function frameworkFormula() {
         echoSuccess " flags: \"$1\" \"$xcframework_flags\" "
         HERE_DIR=$(cd $(dirname "./"); pwd -P)
         cd "${LIBS_DIR_REAL}/${1}/lib/${TYPE}/"
-        xcodebuild -create-xcframework $xcframework_flags -output $1.xcframework
 
         XCFRAMEWORK_PATH="${LIBS_DIR_REAL}/${1}/lib/${TYPE}/$1.xcframework"
+        xcodebuild -create-xcframework $xcframework_flags -output $1.xcframework
+
+        XDIR="${XLIBS_DIR_REAL}/"
+        X_LIBS=$XDIR/${1}/lib/${TYPE}/
+        X_INCLUDE=$XDIR/${1}/include
+        X_LICENSE=$XDIR/${1}/license
+        mkdir -p "${X_LIBS}"
+
+        XDIR="X${LIBS_DIR_REAL}/${1}/lib/${TYPE}/"
+        mkdir -p "${XDIR}"
+
+        
+
         # Loop over each .a file found within the xcframework
         find "$XCFRAMEWORK_PATH" -type f -name "*.a" | while read -r lib_a; do
             echo "Securing $lib_a..."
             lipo -info "$lib_a"
             xcrun codesign --sign - "$lib_a" || true
-             . "$SECURE_SCRIPT"
+            . "$SECURE_SCRIPT"
             secure "$lib_a" "$LIB_NAME" "$VERSION"
         done
+
+        echoSuccess " xcframework for [$TYPE] transferring to [$XDIR]"
+        if ! command -v rsync &> /dev/null; then      
+            cp -av "${XCFRAMEWORK_PATH}/"* ${X_LIBS}
+            cp -av "${LIBS_DIR_REAL}/${1}/include/"* ${X_INCLUDE}
+            cp -av "${LIBS_DIR_REAL}/${1}/license/"* ${X_LICENSE}
+        else
+            rsync -av --delete "${XCFRAMEWORK_PATH}" ${X_LIBS}
+            rsync -av --delete "${LIBS_DIR_REAL}/${1}/include/" ${X_INCLUDE}
+            rsync -av --delete "${LIBS_DIR_REAL}/${1}/license/" ${X_LICENSE}
+        fi
+
+        echo " -- cleanup merged libraries ..." 
+        for dir in "${merged_dirs[@]}"; do
+            echo " removing directory: [$dir]"
+            rm -rfv "${dir}"
+        done 
+
+        rm -rfv "${XCFRAMEWORK_PATH}"
 
         echoSuccess " xcframework for $TYPE built successfully."
         echo "========================"
@@ -1628,6 +1672,14 @@ function xframeworkFormula() {
 
     TYPE=macos
     export LIBS_DIR_REAL=$(realpath $LIBS_DIR)
+
+    XLIBSLOCAL="$LIBS_DIR/../xout"
+    if [[  ! -e "$XLIBSLOCAL/$1/lib/$TYPE" ]] && [[ $TYPE == "macos" ]]; then
+        mkdir -p $XLIBSLOCAL/$1/lib/$TYPE
+    fi
+    export XLIBS_DIR_REAL=$(realpath $XLIBSLOCAL)
+
+    
     PLATFORM_TYPES=("ios" "osx" "catos" "xros" "tvos" "watchos")
     VERSION=""
     DEFINES=""
@@ -1645,10 +1697,17 @@ function xframeworkFormula() {
         if [[  ! -e "$LIBS_DIR_REAL/$1/lib/$TYPE" ]] && [[ $TYPE == "macos" ]]; then
             mkdir -p $LIBS_DIR_REAL/$1/lib/$TYPE
         fi
+        if [[  ! -e "$XLIBS_DIR_REAL/$1/lib/$TYPE" ]] && [[ $TYPE == "macos" ]]; then
+            mkdir -p $XLIBS_DIR_REAL/$1/lib/$TYPE
+        fi
 
         if [[ $TYPE == "macos" ]]; then
             echoSuccess "Building macOS xcframework"
         fi
+
+        XCFRAMEWORK_PATH="${LIBS_DIR_REAL}/${1}/lib/${TYPE}/$1.xcframework"
+
+        rm -rfv "${XCFRAMEWORK_PATH}"
 
         if ((BASH_VERSINFO[0] < 4)); then
             echo "The current version of Bash does not support associative arrays."
@@ -1681,7 +1740,7 @@ function xframeworkFormula() {
                     DIR_PATH="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/$ARCH/"
                     if [ -d "$DIR_PATH" ]; then
                         echo "Processing ARCH: $ARCH"
-                        MERGED_DIR="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/${ARCH}_${PAIR}"
+                        MERGED_DIR="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/MERGE_${ARCH}_${PAIR}"
                         declare -a archive_paths=()
                         while IFS= read -r -d $'\0' file; do
                             archive_paths+=("$file")
@@ -1720,8 +1779,8 @@ function xframeworkFormula() {
                                 mkdir -p "$MERGED_DIR"
                                 echo "MERGED_DIR: $ARCH - Pair: $PAIR"
                                 # Determine the output filename in the merged directory
-                                PATH_MERGE=$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/${ARCH}_${PAIR}/
-                                MERGED_PATH="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/${ARCH}_${PAIR}/$(basename "$ARCH_FILE" .a).a"
+                                PATH_MERGE=$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/MERGE_${ARCH}_${PAIR}/
+                                MERGED_PATH="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/MERGE_${ARCH}_${PAIR}/$(basename "$ARCH_FILE" .a).a"
                                 # Use lipo to merge the architectures into a single file - prevents linking errors
                                 xcrun lipo -create "$ARCH_FILE" "$PAIR_FILE" -output "$MERGED_PATH"
                                 echo "Merged $ARCH_FILE and $PAIR_FILE into $MERGED_PATH"
@@ -1739,9 +1798,15 @@ function xframeworkFormula() {
                                     echo "path_found_in_array == true"
                                 fi
                             else
-                                PATH_MERGE=$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/${ARCH}/
-                                MERGED_PATH="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/${ARCH}/$(basename "$ARCH_FILE" .a).a"
+                                PATH_MERGE=$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/MERGE_${ARCH}/
+                                MERGED_PATH="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/MERGE_${ARCH}/$(basename "$ARCH_FILE" .a).a"
+                                mkdir -p "$PATH_MERGE"
                                 echo "MERGED_PATH: $ARCH - $MERGED_PATH"
+                                if ! command -v rsync &> /dev/null; then    
+                                    rsync -av --include --delete '*/' --include '*.a' --exclude '*' "$DIR_PATH/" "$PATH_MERGE/"
+                                else
+                                    cp -v "$DIR_PATH"/*.a "$PATH_MERGE"
+                                fi
                                 xcrun codesign --sign - $MERGED_PATH || true
                                 if [[ "$num_archive_paths" -gt 1 ]]; then
                                     for dir in "${merged_dirs[@]}"; do
@@ -1777,14 +1842,14 @@ function xframeworkFormula() {
         # Final merging pass to combine binaries of same / merged architectures into single binary to prevent linking issues
         echo "merged_dirs:"
         for dir in "${merged_dirs[@]}"; do
-            echo "Processing directory: $dir"
+            echo "Processing directory: [$dir]"
             rm -f "${dir}/${1}.a"
             a_files=($(find "$dir" -name '*.a' -print0 | xargs -0))
             num_files=${#a_files[@]}
             if [ "$num_files" -gt 1 ]; then
-                echo "Multiple archives found in $dir. Commencing the merge..."
+                echo "Multiple archives found in [$dir]. Commencing the merge..."
                 libtool -static -o "${dir}/${1}.a" "${a_files[@]}"
-                echo "Merged into ${dir}/${1}.a"
+                echo "Merged into [${dir}/${1}.a]"
                 for a_file in "${a_files[@]}"; do
                     rm -f "$a_file"
                 done
@@ -1794,11 +1859,14 @@ function xframeworkFormula() {
                     xcframework_flags+=" -library ${dir}/${1}.a"
                     xcframework_flags+=" -headers $LIBS_DIR_REAL/$1/include"
                 fi
-            else
+            elif [ "$num_files" -gt 0 ]; then
                 # Directly use the single archive or skip if none
+                echo "Directly use the single archive or skip if none ${a_files[0]}]"
                 xcframework_flags+=" -library ${a_files[0]}"
                 xcframework_flags+=" -headers $LIBS_DIR_REAL/$1/include"
-             fi
+            else
+                echo " Skip for [$dir]]"
+            fi
         done
 
         echoSuccess " flags: \"$1\" \"$xcframework_flags\" "
@@ -1810,7 +1878,13 @@ function xframeworkFormula() {
         
         cd $HERE_DIR
 
-        XCFRAMEWORK_PATH="${LIBS_DIR_REAL}/${1}/lib/${TYPE}/$1.xcframework"
+        XDIR="${XLIBS_DIR_REAL}/"
+        X_LIBS=$XDIR/${1}/lib/${TYPE}/
+        X_INCLUDE=$XDIR/${1}/include
+        X_LICENSE=$XDIR/${1}/license
+        mkdir -p "${X_LIBS}"
+
+
         # Loop over each .a file found within the xcframework
         find "$XCFRAMEWORK_PATH" -type f -name "*.a" | while read -r lib_a; do
             echo "Securing $lib_a..."
@@ -1820,20 +1894,38 @@ function xframeworkFormula() {
             secure "$lib_a" "$LIB_NAME" "$VERSION"
         done
 
-        # codesign --timestamp -s  $XCFRAMEWORK_PATH
+        echo " -- deploy to xcframework [$X_LIBS]..." 
+        if ! command -v rsync &> /dev/null; then      
+            cp -av "${XCFRAMEWORK_PATH}/"* ${X_LIBS}
+            cp -av "${LIBS_DIR_REAL}/${1}/include/"* ${X_INCLUDE}
+            cp -av "${LIBS_DIR_REAL}/${1}/license/"* ${X_LICENSE}
+        else
+            rsync -av --delete "${XCFRAMEWORK_PATH}" ${X_LIBS}
+            rsync -av --delete "${LIBS_DIR_REAL}/${1}/include/" ${X_INCLUDE}
+            rsync -av --delete "${LIBS_DIR_REAL}/${1}/license/" ${X_LICENSE}
+        fi
 
-        for PLATFORM in "${PLATFORM_TYPES[@]}"; do
-            PLATFORM_DIR="${LIBS_DIR_REAL}/${1}/lib/$PLATFORM"
-            echo "Cleaning up $PLATFORM platform type..."
-            if [ -d "$PLATFORM_DIR" ]; then
-                dirs_to_clean=$(find "${LIBS_DIR_REAL}/${1}/lib/$PLATFORM/" -mindepth 1 -maxdepth 1 -type d ! -name "*.xcframework")
-                for dir in $dirs_to_clean; do
-                    echo "Removing directory: $dir"
-                    rm -rf "$dir"
-                done
-                rm -rf "$PLATFORM_DIR"
-            fi
-        done
+        echo " -- cleanup merged libraries ..." 
+        for dir in "${merged_dirs[@]}"; do
+            echo " removing directory: [$dir]"
+            rm -rfv "${dir}"
+        done 
+
+        rm -rfv "${XCFRAMEWORK_PATH}"
+
+        # codesign --timestamp -s  $XCFRAMEWORK_PATH
+        # for PLATFORM in "${PLATFORM_TYPES[@]}"; do
+        #     PLATFORM_DIR="${LIBS_DIR_REAL}/${1}/lib/$PLATFORM"
+        #     echo "Cleaning up $PLATFORM platform type..."
+        #     if [ -d "$PLATFORM_DIR" ]; then
+        #         dirs_to_clean=$(find "${LIBS_DIR_REAL}/${1}/lib/$PLATFORM/" -mindepth 1 -maxdepth 1 -type d ! -name "*.xcframework")
+        #         for dir in $dirs_to_clean; do
+        #             echo "Removing directory: $dir"
+        #             rm -rf "$dir"
+        #         done
+        #         rm -rf "$PLATFORM_DIR"
+        #     fi
+        # done
     fi
 }
 

--- a/scripts/catos/build_and_deploy_all.sh
+++ b/scripts/catos/build_and_deploy_all.sh
@@ -34,7 +34,7 @@ if [ -z "${OVERWRITE+x}" ]; then
 fi
 
 if [ -z "${XCFRAMEWORK+x}" ]; then
-    XCFRAMEWORK=0
+    XCFRAMEWORK=1
 fi
 
 export OUTPUT_FOLDER="${ROOT}/out"

--- a/scripts/ios/build_and_deploy_all.sh
+++ b/scripts/ios/build_and_deploy_all.sh
@@ -37,7 +37,7 @@ if [ -z "${OVERWRITE+x}" ]; then
 fi
 
 if [ -z "${XCFRAMEWORK+x}" ]; then
-    XCFRAMEWORK=0
+    XCFRAMEWORK=1
 fi
 
 

--- a/scripts/osx/build_and_deploy_all.sh
+++ b/scripts/osx/build_and_deploy_all.sh
@@ -33,7 +33,7 @@ if [ -z "${OVERWRITE+x}" ]; then
 fi
 
 if [ -z "${XCFRAMEWORK+x}" ]; then
-    XCFRAMEWORK=0
+    XCFRAMEWORK=1
 fi
 
 

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -78,6 +78,13 @@ APOTHECARY_PATH=$ROOT/apothecary
 if [ -z "${OUTPUT_FOLDER+x}" ]; then
     export OUTPUT_FOLDER="$ROOT/out"
 fi
+
+if [[ "$TARGET" =~ ^(osx|ios|tvos|xros|catos|watchos|macos)$ ]]; then
+
+    export OUTPUT_FOLDER="$ROOT/xout"
+fi
+
+
 #OUTPUT_FOLDER=$ROOT/out
 
 

--- a/scripts/tvOS/build_and_deploy_all.sh
+++ b/scripts/tvOS/build_and_deploy_all.sh
@@ -33,7 +33,7 @@ if [ -z "${OVERWRITE+x}" ]; then
 fi
 
 if [ -z "${XCFRAMEWORK+x}" ]; then
-    XCFRAMEWORK=0
+    XCFRAMEWORK=1
 fi
 
 

--- a/scripts/watchos/build_and_deploy_all.sh
+++ b/scripts/watchos/build_and_deploy_all.sh
@@ -33,7 +33,7 @@ if [ -z "${OVERWRITE+x}" ]; then
 fi
 
 if [ -z "${XCFRAMEWORK+x}" ]; then
-    XCFRAMEWORK=0
+    XCFRAMEWORK=1
 fi
 
 # Set OUTPUT_FOLDER for the build

--- a/scripts/xros/build_and_deploy_all.sh
+++ b/scripts/xros/build_and_deploy_all.sh
@@ -37,7 +37,7 @@ if [ -z "${OVERWRITE+x}" ]; then
 fi
 
 if [ -z "${XCFRAMEWORK+x}" ]; then
-    XCFRAMEWORK=0
+    XCFRAMEWORK=1
 fi
 
 


### PR DESCRIPTION
## Apothecary XCFramework 
- retain built binaries and process output in another folder (xout)
- Cleans up rebuild cycles
- Build scripts now build xcframework in process and deploy those 	
- package from xcframeworks out 
- Fix issues on merge
