### PR TITLE
XCFrameworks case fix - + downloader script 3.2.1

### DIFF
--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -1425,6 +1425,8 @@ function cleanFormula() {
 
 function frameworkFormula() {
 
+    echoStart " frameworkFormula [\"$1\"] for:[${TYPE}]"
+
     export LIBS_DIR_REAL=$(realpath $LIBS_DIR)
     XLIBSLOCAL="$APOTHECARY_DIR/../xout"
     if [[  ! -e "$XLIBSLOCAL" ]]; then
@@ -1465,7 +1467,7 @@ function frameworkFormula() {
             ["SIMULATOR64_VISIONOS"]="SIMULATOR_VISIONOS"
         )
         # this gets a bit advanced bash so need Bash 4 - brew install bash if issues arrise... hectic problems 
-        PLATFORM_TYPES=("ios" "osx" )
+        PLATFORM_TYPES=("ios" "osx" "tvos" )
         declare -a merged_dirs=()
         VERSION=""
         LIB_NAME=""

--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -1540,15 +1540,8 @@ function frameworkFormula() {
                                     echo "path_found_in_array == true"
                                 fi
                             else
-                                PATH_MERGE=$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/MERGE_${ARCH}/
-                                MERGED_PATH="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/MERGE_${ARCH}/$(basename "$ARCH_FILE" .a).a"
-                                mkdir -p "$PATH_MERGE"
-                                echo "MERGED_PATH: $ARCH - $MERGED_PATH"
-                                if ! command -v rsync &> /dev/null; then    
-                                    rsync -av --include --delete '*/' --include '*.a' --exclude '*' "$DIR_PATH/" "$PATH_MERGE/"
-                                else
-                                    cp -v "$DIR_PATH"/*.a "$PATH_MERGE"
-                                fi
+                                PATH_MERGE=$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/${ARCH}/
+                                MERGED_PATH="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/${ARCH}/$(basename "$ARCH_FILE" .a).a"
                                 xcrun codesign --sign - $MERGED_PATH || true
                                 if [[ "$num_archive_paths" -gt 1 ]]; then
                                     for dir in "${merged_dirs[@]}"; do
@@ -1559,17 +1552,11 @@ function frameworkFormula() {
                                     done
                                     if [[ $path_found_in_array == false ]]; then
                                         merged_dirs+=("$PATH_MERGE")
-                                        echo "path_found_in_array == false adding $PATH_MERGE"
-                                    else
-                                        echo "path_found_in_array == true"
                                     fi
                                 else
                                     if [[ ! "$xcframework_flags" =~ "$MERGED_PATH" ]]; then
                                         xcframework_flags+=" -library $MERGED_PATH"
                                         xcframework_flags+=" -headers $LIBS_DIR_REAL/$1/include"
-                                        echo "xcframework_flags: adding -library $MERGED_PATH"
-                                    else
-                                        echo "xcframework_flags: not adding already in full flags: $xcframework_flags"
                                     fi
                                 fi
                             fi
@@ -1613,7 +1600,7 @@ function frameworkFormula() {
 
         
 
-       echoSuccess " flags: \"$1\" \"$xcframework_flags\" "
+        echoSuccess " flags: [\"$1\" \"$xcframework_flags\"]"
         HERE_DIR=$(cd $(dirname "./"); pwd -P)
         cd "${LIBS_DIR_REAL}/${1}/lib/${TYPE}/"
         xcodebuild -create-xcframework $xcframework_flags -output $1.xcframework
@@ -1797,15 +1784,8 @@ function xframeworkFormula() {
                                     echo "path_found_in_array == true"
                                 fi
                             else
-                                PATH_MERGE=$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/MERGE_${ARCH}/
-                                MERGED_PATH="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/MERGE_${ARCH}/$(basename "$ARCH_FILE" .a).a"
-                                mkdir -p "$PATH_MERGE"
-                                echo "MERGED_PATH: $ARCH - $MERGED_PATH"
-                                if ! command -v rsync &> /dev/null; then    
-                                    rsync -av --include --delete '*/' --include '*.a' --exclude '*' "$DIR_PATH/" "$PATH_MERGE/"
-                                else
-                                    cp -v "$DIR_PATH"/*.a "$PATH_MERGE"
-                                fi
+                                PATH_MERGE=$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/${ARCH}/
+                                MERGED_PATH="$LIBS_DIR_REAL/$1/lib/$CURRENT_TYPE/${ARCH}/$(basename "$ARCH_FILE" .a).a"
                                 xcrun codesign --sign - $MERGED_PATH || true
                                 if [[ "$num_archive_paths" -gt 1 ]]; then
                                     for dir in "${merged_dirs[@]}"; do
@@ -1816,17 +1796,11 @@ function xframeworkFormula() {
                                     done
                                     if [[ $path_found_in_array == false ]]; then
                                         merged_dirs+=("$PATH_MERGE")
-                                        echo "path_found_in_array == false adding $PATH_MERGE"
-                                    else
-                                        echo "path_found_in_array == true"
                                     fi
                                 else
                                     if [[ ! "$xcframework_flags" =~ "$MERGED_PATH" ]]; then
                                         xcframework_flags+=" -library $MERGED_PATH"
                                         xcframework_flags+=" -headers $LIBS_DIR_REAL/$1/include"
-                                        echo "xcframework_flags: adding -library $MERGED_PATH"
-                                    else
-                                        echo "xcframework_flags: not adding already in full flags: $xcframework_flags"
                                     fi
                                 fi
                             fi

--- a/apothecary/formulas/boost/boost.sh
+++ b/apothecary/formulas/boost/boost.sh
@@ -5,7 +5,7 @@
 #
 # uses a own build system
 
-FORMULA_TYPES=( "osx" )
+FORMULA_TYPES=(  )
 
 # define the version
 VERSION=1.66.0

--- a/apothecary/formulas/openssl/openssl.sh
+++ b/apothecary/formulas/openssl/openssl.sh
@@ -54,26 +54,26 @@ DEFS=" -DOPENSSL_NO_DEPRECATED=ON \
 function download() {
 
 	. "$DOWNLOADER_SCRIPT"
-	FILENAME=openssl-$VER
+	FILE_NAME=openssl-$VER
 
-	if ! [ -f $FILENAME ]; then
-		downloader "${MIRROR}/source/${FILENAME}.tar.gz" 
+	if ! [ -f $FILE_NAME ]; then
+		downloader "${MIRROR}/source/${FILE_NAME}.tar.gz" 
 	fi
 
-	if ! [ -f $FILENAME.sha1 ]; then
-		downloader ${MIRROR}/source/$FILENAME.tar.gz.sha1
+	if ! [ -f $FILE_NAME.sha1 ]; then
+		downloader ${MIRROR}/source/$FILE_NAME.tar.gz.sha1
 	fi
-	CHECKSHA=$(shasum $FILENAME.tar.gz | awk '{print $1}')
-	FILESUM=$(head -1 $FILENAME.tar.gz.sha1)
+	CHECKSHA=$(shasum $FILE_NAME.tar.gz | awk '{print $1}')
+	FILESUM=$(head -1 $FILE_NAME.tar.gz.sha1)
 	if [[ " $CHECKSHA" != $FILESUM || $CHECKSHA != "$SHA1" ]] ;  then
 		echoError "SHA did not Verify: [$CHECKSHA] SHA on Record:[$SHA1] FILESUM=[$FILESUM]- Developer has not updated SHA or Man in the Middle Attack"
     	exit
     else
-    	tar -xf "${FILENAME}.tar.gz"
+    	tar -xf "${FILE_NAME}.tar.gz"
 		echo "SHA for Download Verified Successfully: [$CHECKSHA] SHA on Record:[$SHA1]"
-		mv $FILENAME openssl_temp
-		rm $FILENAME.tar.gz
-		rm $FILENAME.tar.gz.sha1
+		mv $FILE_NAME openssl_temp
+		rm $FILE_NAME.tar.gz
+		rm $FILE_NAME.tar.gz.sha1
 	fi
 	# Clone the openssl-cmake repository
 	git clone --branch "3.3" --depth=1 $GIT_URL openssl_cmake_temp

--- a/scripts/downloader.sh
+++ b/scripts/downloader.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-VERSION=3.2.2
+VERSION=3.2.3
 printDownloaderHelp(){
 cat << EOF
     
@@ -152,7 +152,7 @@ downloader() {
             check_remote_vs_local "$LOCAL_FILE" "$REMOTE_URL"
             if [ $CHECK_RESULT -eq 0 ]; then
                 URLS_TO_DOWNLOAD+="${URL} -o ${FILENAME} "
-                if [ -n "${URLS[$i+1]}" ]; then
+                if [ $((i + 1)) -lt ${#URLS[@]} ]; then
                     URLS_TO_DOWNLOAD+="-k ";
                 fi
             else

--- a/scripts/downloader.sh
+++ b/scripts/downloader.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+VERSION=3.2.1
 printDownloaderHelp(){
 cat << EOF
     
@@ -26,26 +26,74 @@ validate_url(){
     fi
 }
 
+#!/bin/bash
+
+CHECK_RESULT=0
+check_remote_vs_local() {
+  LOCAL_FILE="$1"
+  REMOTE_URL="$2"
+
+  if [ ! -f "$LOCAL_FILE" ]; then
+    echo "  cURL [check_remote_vs_local] - LOCAL_FILE:[$LOCAL_FILE] not found. Download"
+    CHECK_RESULT=0
+    return
+  else
+    echo "  cURL [check_remote_vs_local] - LOCAL_FILE:[$LOCAL_FILE] exists"
+  fi
+
+  # Get local file size
+  LocalSize=$(wc -c < "$LOCAL_FILE")
+
+  # Get remote file size
+  RemoteSize=$(curl -sI -L --retry 20 "$REMOTE_URL" | awk '/Content-Length/ {print $2}' | tr -d '\r' | tail -n 1)
+
+  # Get remote file modification time
+  modified=$(curl -L --retry 20 --silent --head "$REMOTE_URL" | awk '/^Last-Modified/{print $0}' | sed 's/^Last-Modified: //')
+  remote_ctime=$(date --date="$modified" +%s)
+
+  # Get local file modification time
+  local_ctime=$(stat -c %z "$LOCAL_FILE")
+  local_ctime=$(date --date="$local_ctime" +%s)
+
+  # Check size
+  if [ "$LocalSize" != "$RemoteSize" ]; then
+    echo "  File sizes differ. Run the cURL. LocalSize:[$LocalSize] RemoteSize:[$RemoteSize]"
+    CHECK_RESULT=0
+    return
+  fi
+
+  # Check modification time
+  if [ "$local_ctime" -lt "$remote_ctime" ]; then
+    echo "  Remote file is newer. Run the cURL. local_ctime[$local_ctime] remote_ctime:[$remote_ctime]"
+    CHECK_RESULT=0
+    return
+  fi
+
+  echo "  Files are the same. Do not run the cURL."
+  CHECK_RESULT=1
+  return
+}
+
 downloader() { 
-    echo " [downloader] ... "
+    echo " [openFrameworks downloader v${VERSION}] ... "
     if [ -z "$1" ]; then 
         printDownloaderHelp
         exit 1
     fi
+    ERROR_MSG=" Downloading failed: No Installed: wget2, curl or wget. Please install (via homebrew, winget, apt-get) and try again. "
     SILENT=0
     NO_SSL=0
     URLS=()
-
     while [[ $# -gt 0 ]]; do
         key="$1"
         case $key in
             -s|--silent)
             SILENT=1
-            shift # past argument
+            shift
             ;;
             -k|--no-ssl)
             NO_SSL=1
-            shift # past argument
+            shift
             ;;
             -h|--help)
             printDownloaderHelp
@@ -56,46 +104,88 @@ downloader() {
                 URLS+=("$1")
             else
                 if [ $1 != "0" ]; then 
-                    echo "Invalid URL: [$1]"
+                    echo " Invalid URL: [$1]"
                 fi
             fi
-            shift # past argument
+            shift
             ;;
         esac
     done
-
+    WGET2_INSTALLED=$(command -v wget2 > /dev/null 2>&1; echo $?)
+    CURL_INSTALLED=$(command -v curl > /dev/null 2>&1; echo $?)
+    WGET_INSTALLED=$(command -v wget > /dev/null 2>&1; echo $?)
+    WGET2=1
+    CURL=1
+    WGET=1
     SSL_ARGS=""
     if [[ "$NO_SSL" == "1" ]]; then 
-        echo "no SSL == 1"
-        if command -v wget2 > /dev/null 2>&1; then
+        if  [[ $WGET2 == 1 ]] && [[ $WGET2_INSTALLED == 0 ]]; then
             SSL_ARGS="--no-check-certificate"
-        elif command -v curl > /dev/null 2>&1; then
+        elif [[ $CURL == 1 ]] && [[ $CURL_INSTALLED == 0 ]]; then
             SSL_ARGS="--insecure"
         else
             SSL_ARGS="--no-check-certificate"
         fi
-        echo " [Warning SSL Validation is Disabled with -k or --no-ssl]"
+        echo " [WARNING SSL Validation is Disabled with -k or --no-ssl]"
     fi
-
-    for URL in "${URLS[@]}"; do
-        DL_FILENAME=$(basename "$URL")
-        echo "Downloading [$DL_FILENAME] @ [$URL]"
-        if [[ "${SILENT}" == "1" ]]; then
-            if command -v wget2 2>/dev/null; then
-                wget2 -q $URL 2> /dev/null;
-            elif command -v curl 2>/dev/null; then
-                curl -L --parallel --retry 20 -s $SSL_ARGS -N -O $URL;
+    URLS_TO_DOWNLOAD=""
+    for ((i = 0; i < ${#URLS[@]}; i++)); do
+        URL="${URLS[$i]}"
+        FILENAME=$(basename "$URL")
+        if  [[ $WGET2 == 1 ]] && [[ $WGET2_INSTALLED == 0 ]]; then
+            URLS_TO_DOWNLOAD+="${URL} "
+        elif [[ $CURL == 1 ]] && [[ $CURL_INSTALLED == 0 ]]; then
+            LOCAL_FILE=$FILENAME
+            REMOTE_URL=$URL
+            check_remote_vs_local "$LOCAL_FILE" "$REMOTE_URL"
+            if [ $CHECK_RESULT -eq 0 ]; then
+                URLS_TO_DOWNLOAD+="${URL} -o ${FILENAME} "
+                if [ -n "${URLS[$i+1]}" ]; then
+                    URLS_TO_DOWNLOAD+="-k ";
+                fi
             else
-                wget -q $URL 2> /dev/null;
-            fi;
-        else
-             if command -v wget2 2>/dev/null; then
-                wget2 --progress=bar $URL 2> /dev/null;
-            elif command -v curl 2>/dev/null; then
-                curl -L --parallel --retry 20 --progress-bar -N $SSL_ARGS -O $URL || echo $?;
-            else
-                wget --progress=bar $URL 2> /dev/null;
+                echo "  LOCAL_FILE:[${LOCAL_FILE}] is same as remote - skipping download"
             fi
+        else
+           URLS_TO_DOWNLOAD+="${URL} "
         fi
     done
+    echo
+    if [ -z "$URLS_TO_DOWNLOAD" ]; then
+        echo "  No URLS to download, continue"
+    else
+        if [[ "${SILENT}" == 1 ]]; then
+            if  [[ $WGET2 == 1 ]] && [[ $WGET2_INSTALLED == 0 ]]; then
+                echo
+                wget2 -nv --progress=bar -N -t20 $SSL_ARGS $URLS_TO_DOWNLOAD
+            elif [[ $CURL == 1 ]] && [[ $CURL_INSTALLED == 0 ]]; then
+                echo
+                curl -L --retry 20 --progress-bar $SSL_ARGS ${URLS_TO_DOWNLOAD}
+            elif [[ $WGET == 1 ]] && [[ $WGET_INSTALLED == 0 ]]; then
+                echo
+                wget -nv -N -t20 ${URLS_TO_DOWNLOAD} 
+            else 
+                echo $ERROR_MSG;
+                exit 1;
+            fi;
+        else
+            if [[ $WGET2 == 1 ]] && [[ $WGET2_INSTALLED == 0 ]]; then # 0 means true in this context
+                echo " Downloading [wget2] urls:[$URLS_TO_DOWNLOAD]"
+                echo
+                wget2 -N -nv --progress=bar -t20 $SSL_ARGS ${URLS_TO_DOWNLOAD}
+            elif [[ $CURL == 1 ]] && [[ $CURL_INSTALLED == 0 ]]; then
+                echo " Downloading [cURL] urls:[$URLS_TO_DOWNLOAD]"
+                echo
+                curl -L --retry 20 --progress-bar $SSL_ARGS ${URLS_TO_DOWNLOAD}
+            elif [[ $WGET == 1 ]] && [[ $WGET_INSTALLED == 0 ]]; then
+                echo " Downloading [wget] [$FILENAME] urls:[$URLS_TO_DOWNLOAD]"
+                echo
+                wget -nv --progress=bar -N -t20 $SSL_ARGS $URLS_TO_DOWNLOAD
+            else 
+                echo $ERROR_MSG;
+                exit 1;
+            fi
+        fi
+    fi
+    echo
 }

--- a/scripts/downloader.sh
+++ b/scripts/downloader.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-VERSION=3.2.1
+VERSION=3.2.2
 printDownloaderHelp(){
 cat << EOF
     
@@ -111,9 +111,21 @@ downloader() {
             ;;
         esac
     done
-    WGET2_INSTALLED=$(command -v wget2 > /dev/null 2>&1; echo $?)
-    CURL_INSTALLED=$(command -v curl > /dev/null 2>&1; echo $?)
-    WGET_INSTALLED=$(command -v wget > /dev/null 2>&1; echo $?)
+    if command -v wget2 > /dev/null 2>&1; then
+        WGET2_INSTALLED=1
+    else
+        WGET2_INSTALLED=0
+    fi
+    if command -v curl > /dev/null 2>&1; then
+        CURL_INSTALLED=1
+    else
+        CURL_INSTALLED=0
+    fi
+    if command -v wget > /dev/null 2>&1; then
+        WGET_INSTALLED=1
+    else
+        WGET_INSTALLED=0
+    fi
     WGET2=1
     CURL=1
     WGET=1
@@ -132,9 +144,9 @@ downloader() {
     for ((i = 0; i < ${#URLS[@]}; i++)); do
         URL="${URLS[$i]}"
         FILENAME=$(basename "$URL")
-        if  [[ $WGET2 == 1 ]] && [[ $WGET2_INSTALLED == 0 ]]; then
+        if  [[ $WGET2 == 1 ]] && [[ $WGET2_INSTALLED == 1 ]]; then
             URLS_TO_DOWNLOAD+="${URL} "
-        elif [[ $CURL == 1 ]] && [[ $CURL_INSTALLED == 0 ]]; then
+        elif [[ $CURL == 1 ]] && [[ $CURL_INSTALLED == 1 ]]; then
             LOCAL_FILE=$FILENAME
             REMOTE_URL=$URL
             check_remote_vs_local "$LOCAL_FILE" "$REMOTE_URL"
@@ -155,13 +167,13 @@ downloader() {
         echo "  No URLS to download, continue"
     else
         if [[ "${SILENT}" == 1 ]]; then
-            if  [[ $WGET2 == 1 ]] && [[ $WGET2_INSTALLED == 0 ]]; then
+            if  [[ $WGET2 == 1 ]] && [[ $WGET2_INSTALLED == 1 ]]; then
                 echo
                 wget2 -nv --progress=bar -N -t20 $SSL_ARGS $URLS_TO_DOWNLOAD
-            elif [[ $CURL == 1 ]] && [[ $CURL_INSTALLED == 0 ]]; then
+            elif [[ $CURL == 1 ]] && [[ $CURL_INSTALLED == 1 ]]; then
                 echo
                 curl -L --retry 20 --progress-bar $SSL_ARGS ${URLS_TO_DOWNLOAD}
-            elif [[ $WGET == 1 ]] && [[ $WGET_INSTALLED == 0 ]]; then
+            elif [[ $WGET == 1 ]] && [[ $WGET_INSTALLED == 1 ]]; then
                 echo
                 wget -nv -N -t20 ${URLS_TO_DOWNLOAD} 
             else 
@@ -169,15 +181,15 @@ downloader() {
                 exit 1;
             fi;
         else
-            if [[ $WGET2 == 1 ]] && [[ $WGET2_INSTALLED == 0 ]]; then # 0 means true in this context
+            if [[ $WGET2 == 1 ]] && [[ $WGET2_INSTALLED == 1 ]]; then 
                 echo " Downloading [wget2] urls:[$URLS_TO_DOWNLOAD]"
                 echo
                 wget2 -N -nv --progress=bar -t20 $SSL_ARGS ${URLS_TO_DOWNLOAD}
-            elif [[ $CURL == 1 ]] && [[ $CURL_INSTALLED == 0 ]]; then
+            elif [[ $CURL == 1 ]] && [[ $CURL_INSTALLED == 1 ]]; then
                 echo " Downloading [cURL] urls:[$URLS_TO_DOWNLOAD]"
                 echo
                 curl -L --retry 20 --progress-bar $SSL_ARGS ${URLS_TO_DOWNLOAD}
-            elif [[ $WGET == 1 ]] && [[ $WGET_INSTALLED == 0 ]]; then
+            elif [[ $WGET == 1 ]] && [[ $WGET_INSTALLED == 1 ]]; then
                 echo " Downloading [wget] [$FILENAME] urls:[$URLS_TO_DOWNLOAD]"
                 echo
                 wget -nv --progress=bar -N -t20 $SSL_ARGS $URLS_TO_DOWNLOAD

--- a/scripts/osx/install.sh
+++ b/scripts/osx/install.sh
@@ -2,7 +2,7 @@
 brew update >/dev/null
 
 
-brew install cmake coreutils autoconf automake ccache gtk-doc brotli libtool wget fontconfig bash shfmt
+brew install cmake coreutils autoconf automake ccache gtk-doc brotli libtool wget fontconfig bash shfmt wget2 curl
 
 # brew reinstall libtool
 


### PR DESCRIPTION
Testing working fix for XCFramework merge on the case of:
- output target with no merge (like arm64 and 64 is normal case), if just arm64, and the library has multiple binaries in that folder, this was causing an issue 

Updated downloader script to 3.2.1 