### PR TITLE
Fix missing Libraries in final packages

### DIFF
--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -1442,7 +1442,22 @@ function frameworkFormula() {
         echoSuccess " Framework lib dest dir: \"$1\" \"$LIBS_DIR_REAL/$1/lib/$TYPE/\" "
         xcframework_flags=""
 
-        if [[ $1 == "fmod" ]] || [[ $1 == "glm" ]] || [[ $1 == "json" ]] || [[ $1 == "libusb" ]] || [[ $1 == "utf8" ]]; then
+        XDIR="${XLIBS_DIR_REAL}/"
+        X_LIBS="$XDIR/${1}/lib/${TYPE}/"
+        X_INCLUDE=$XDIR/${1}/include
+        X_LICENSE=$XDIR/${1}/license
+        mkdir -p "${X_LIBS}"
+
+        if [[ $1 == "fmod" ]] || [[ $1 == "fmodex" ]]|| [[ $1 == "glm" ]] || [[ $1 == "json" ]] || [[ $1 == "utf8" ]]; then
+            if ! command -v rsync &> /dev/null; then      
+                cp -av "${LIBS_DIR_REAL}/${1}/lib/"* ${X_LIBS}
+                cp -av "${LIBS_DIR_REAL}/${1}/include/"* ${X_INCLUDE}
+                cp -av "${LIBS_DIR_REAL}/${1}/license/"* ${X_LICENSE}
+            else
+                rsync -av --delete "${LIBS_DIR_REAL}/${1}/lib/" ${X_LIBS}
+                rsync -av --delete "${LIBS_DIR_REAL}/${1}/include/" ${X_INCLUDE}
+                rsync -av --delete "${LIBS_DIR_REAL}/${1}/license/" ${X_LICENSE}
+            fi
             exit 0;
         fi
 
@@ -1611,11 +1626,6 @@ function frameworkFormula() {
         
         cd $HERE_DIR
 
-        XDIR="${XLIBS_DIR_REAL}/"
-        X_LIBS="$XDIR/${1}/lib/${TYPE}/"
-        X_INCLUDE=$XDIR/${1}/include
-        X_LICENSE=$XDIR/${1}/license
-        mkdir -p "${X_LIBS}"
 
         
 
@@ -1687,7 +1697,22 @@ function xframeworkFormula() {
         echoSuccess " Framework lib dest dir: \"$1\" \"$LIBS_DIR_REAL/$1/lib/$TYPE/\" "
         xcframework_flags=""
 
-        if [[ $1 == "fmod" ]] || [[ $1 == "glm" ]] || [[ $1 == "json" ]] || [[ $1 == "libusb" ]] || [[ $1 == "utf8" ]]; then
+        XDIR="${XLIBS_DIR_REAL}/"
+        X_LIBS="$XDIR/${1}/lib/${TYPE}/"
+        X_INCLUDE=$XDIR/${1}/include
+        X_LICENSE=$XDIR/${1}/license
+        mkdir -p "${X_LIBS}"
+
+        if [[ $1 == "fmod" ]] || [[ $1 == "fmodex" ]]|| [[ $1 == "glm" ]] || [[ $1 == "json" ]] || [[ $1 == "utf8" ]]; then
+            if ! command -v rsync &> /dev/null; then      
+                cp -av "${LIBS_DIR_REAL}/${1}/lib/"* ${X_LIBS}
+                cp -av "${LIBS_DIR_REAL}/${1}/include/"* ${X_INCLUDE}
+                cp -av "${LIBS_DIR_REAL}/${1}/license/"* ${X_LICENSE}
+            else
+                rsync -av --delete "${LIBS_DIR_REAL}/${1}/lib/" ${X_LIBS}
+                rsync -av --delete "${LIBS_DIR_REAL}/${1}/include/" ${X_INCLUDE}
+                rsync -av --delete "${LIBS_DIR_REAL}/${1}/license/" ${X_LICENSE}
+            fi
             exit 0;
         fi
     
@@ -1854,13 +1879,6 @@ function xframeworkFormula() {
         echo "========================"
         
         cd $HERE_DIR
-
-        XDIR="${XLIBS_DIR_REAL}/"
-        X_LIBS="$XDIR/${1}/lib/${TYPE}/"
-        X_INCLUDE=$XDIR/${1}/include
-        X_LICENSE=$XDIR/${1}/license
-        mkdir -p "${X_LIBS}"
-
 
         # Loop over each .a file found within the xcframework
         find "$XCFRAMEWORK_PATH" -type f -name "*.a" | while read -r lib_a; do

--- a/apothecary/formulas/libusb/libusb.sh
+++ b/apothecary/formulas/libusb/libusb.sh
@@ -154,7 +154,12 @@ function copy() {
 		secure $1/lib/$TYPE/$PLATFORM/libusb.a libusb.pkl
 	fi
 
-	echoWarning "TODO: License Copy"
+	# copy license file
+    if [ -d "$1/license" ]; then
+        rm -r $1/license
+    fi
+    mkdir -p $1/license
+    cp -v COPYING $1/license/
 }
 
 # executed inside the lib src dir

--- a/apothecary/formulas/svgtiny/svgtiny.sh
+++ b/apothecary/formulas/svgtiny/svgtiny.sh
@@ -245,6 +245,7 @@ function build() {
             -DCMAKE_C_STANDARD=17 \
             -DCMAKE_CXX_STANDARD=17 \
             -DDO_XML_INSTALL=ON \
+            -GXcode \
             -DCMAKE_CXX_STANDARD_REQUIRED=ON \
             -DCMAKE_CXX_EXTENSIONS=ON \
             -DDEPLOYMENT_TARGET=${MIN_SDK_VER} \
@@ -318,7 +319,7 @@ function copy() {
         secure $1/lib/$TYPE/$PLATFORM/libsvgtiny.a svgtiny.pkl
 	elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos)$ ]]; then
 		mkdir -p $1/lib/$TYPE/$PLATFORM/
-		cp -v "build_${TYPE}_${PLATFORM}/libsvgtiny.a" $1/lib/$TYPE/$PLATFORM/libsvgtiny.a
+		cp -v "build_${TYPE}_${PLATFORM}/Release/libsvgtiny.a" $1/lib/$TYPE/$PLATFORM/libsvgtiny.a
 		. "$SECURE_SCRIPT"
         secure $1/lib/$TYPE/$PLATFORM/libsvgtiny.a svgtiny.pkl
 	elif [ "$TYPE" == "android" ] ; then


### PR DESCRIPTION
Fix up for deployment phases by copying missing non-built libraries into final output folders

Issue caused when using cache directory and separating binaries /.a from xcframework output for optimisation and no requirement of rebuilding

fixed libusb copying license file 

