### PR TITLE
Update json.sh

### DIFF
--- a/apothecary/formulas/json.sh
+++ b/apothecary/formulas/json.sh
@@ -9,7 +9,7 @@ FORMULA_TYPES=( "osx" "msys2" "linux" "linux64" "linuxarmv6l" "linuxarmv7l" "lin
 FORMULA_DEPENDS=( )
 
 # define the version
-VER=3.11.2
+VER=3.11.3
 BUILD_ID=2
 DEFINES=""
 


### PR DESCRIPTION
main purpose is for migrate off deprecated char_traits.

> Fix char_traits deprecation warning "char_traits<unsigned char> is deprecated: char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard"

https://github.com/nlohmann/json/releases/tag/v3.11.3