### PR TITLE
OpenSSL / cURL - Update

### DIFF
--- a/apothecary/formulas/curl/apple-patch.diff
+++ b/apothecary/formulas/curl/apple-patch.diff
@@ -1,0 +1,34 @@
+From f2cc7ed01c98d6083f4df4e6914759c18cd061ed Mon Sep 17 00:00:00 2001
+From: Dan Rosser <danoli3@gmail.com>
+Date: Wed, 13 Nov 2024 00:46:50 +1100
+Subject: [PATCH] macOS fix for tool_paramhlp.c getpass
+
+---
+ src/tool_paramhlp.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/tool_paramhlp.c b/src/tool_paramhlp.c
+index d4024e134..da47456c9 100644
+--- a/src/tool_paramhlp.c
++++ b/src/tool_paramhlp.c
+@@ -566,7 +566,17 @@ static CURLcode checkpasswd(const char *kind, /* for what purpose */
+                 kind, *userpwd, i + 1);
+ 
+     /* get password */
++#ifdef __APPLE__
++  char *input = getpass(prompt);
++  if (input) {
++      strncpy(passwd, input, sizeof(passwd) - 1);
++      passwd[sizeof(passwd) - 1] = '\0';  // null termination
++  } else {
++      passwd[0] = '\0';
++  }
++#else
+     getpass_r(prompt, passwd, sizeof(passwd));
++#endif
+     if(osep)
+       *osep = ';';
+ 
+-- 
+2.46.0.windows.1
+

--- a/apothecary/formulas/curl/curl.sh
+++ b/apothecary/formulas/curl/curl.sh
@@ -12,16 +12,15 @@ FORMULA_DEPENDS=( "openssl" "zlib" "brotli" )
 # Android to implementation 'com.android.ndk.thirdparty:curl:7.79.1-beta-1'
 
 
-VER=8.9.1
-VER_D=8_9_1
-SHA1=9bcf387f274ae96ad591115d9f9f23700ec76ceb
+VER=8.11.0
+VER_D=8_11_0
+SHA1=9648c31756362343f1a0daba881e189d6fe8b4f4
 BUILD_ID=1
 DEFINES=""
 
 # tools for git use
 GIT_URL=https://github.com/curl/curl
 GIT_TAG=$VER
-
 
 # download the source code and unpack it into LIB_NAME
 function download() {

--- a/apothecary/formulas/curl/curl.sh
+++ b/apothecary/formulas/curl/curl.sh
@@ -310,6 +310,7 @@ function build() {
             -DCMAKE_CXX_EXTENSIONS=OFF \
             -DBUILD_SHARED_LIBS=OFF \
             -DCMAKE_IGNORE_PATH=/opt/homebrew \
+            -DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON \
             -DCURL_STATICLIB=ON \
             -DBUILD_STATIC_LIBS=ON \
             -DENABLE_UNICODE=ON \

--- a/apothecary/formulas/curl/curl.sh
+++ b/apothecary/formulas/curl/curl.sh
@@ -59,8 +59,16 @@ function prepare() {
     apothecaryDepend prepare openssl
     apothecaryDepend build openssl
     apothecaryDepend copy openssl  
-    
 
+    if [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos)$ ]]; then
+        patch -p1 < "$FORMULA_DIR/apple-patch.diff"
+        if [ $? -ne 0 ]; then
+            echo "Failed to apply apple-patch.diff"
+            exit 1
+        else
+            echo "apple-patch.diff applied successfully"
+        fi
+    fi 
     echo "prepared"
 
 
@@ -293,8 +301,8 @@ function build() {
             -DCMAKE_C_STANDARD=${C_STANDARD} \
             -DCMAKE_CXX_STANDARD=${CPP_STANDARD} \
             -DCMAKE_CXX_STANDARD_REQUIRED=ON \
-            -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${FLAG_RELEASE} " \
-            -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${FLAG_RELEASE} -DHAVE_GETPASS_R=0" \
+            -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${FLAG_RELEASE} -DHAVE_GETPASS_R=0 -Wno-error=implicit-function-declaration" \
+            -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${FLAG_RELEASE} -DHAVE_GETPASS_R=0 -Wno-error=implicit-function-declaration" \
             -DCMAKE_CXX_EXTENSIONS=OFF \
             -DBUILD_SHARED_LIBS=OFF \
             -DCURL_STATICLIB=ON \

--- a/apothecary/formulas/curl/curl.sh
+++ b/apothecary/formulas/curl/curl.sh
@@ -305,8 +305,8 @@ function build() {
             -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${FLAG_RELEASE} -Wno-error=implicit-function-declaration" \
             -DENABLE_STRICT_TRY_COMPILE=ON \
             -DHAVE_GETPASS_R=0 \
-            -DCURL_DISABLE_LIBSSH2=ON \
-            -DCURL_DISABLE_LIBPSL=ON \
+            -DCURL_USE_LIBSSH2=OFF \
+            -DCURL_USE_LIBPSL=OFF \
             -DCMAKE_CXX_EXTENSIONS=OFF \
             -DBUILD_SHARED_LIBS=OFF \
             -DCMAKE_IGNORE_PATH=/opt/homebrew \

--- a/apothecary/formulas/curl/curl.sh
+++ b/apothecary/formulas/curl/curl.sh
@@ -156,6 +156,7 @@ function build() {
             -DBROTLI_INCLUDE_DIRS="${LIBBROTLI_INCLUDE_DIR}" \
             -DUSE_RESOLVE_ON_IPS=OFF \
             -DENABLE_ARES=OFF \
+            -DHAVE__FSEEKI64=OFF \
             -DCMAKE_VERBOSE_MAKEFILE=${VERBOSE_MAKEFILE} \
             ${CMAKE_WIN_SDK} \
             -DOPENSSL_ROOT_DIR="$OF_LIBS_OPENSSL_ABS_PATH" \
@@ -304,6 +305,7 @@ function build() {
             -DCMAKE_INSTALL_PREFIX=Release \
             -DDEPLOYMENT_TARGET=${MIN_SDK_VER} \
             -DCMAKE_INCLUDE_OUTPUT_DIRECTORY=include \
+            -DHAVE__FSEEKI64=OFF \
             -DCMAKE_INSTALL_INCLUDEDIR=include \
             -DCMAKE_TOOLCHAIN_FILE=$APOTHECARY_DIR/toolchains/ios.toolchain.cmake \
             -DPLATFORM=$PLATFORM \

--- a/apothecary/formulas/curl/curl.sh
+++ b/apothecary/formulas/curl/curl.sh
@@ -301,8 +301,10 @@ function build() {
             -DCMAKE_C_STANDARD=${C_STANDARD} \
             -DCMAKE_CXX_STANDARD=${CPP_STANDARD} \
             -DCMAKE_CXX_STANDARD_REQUIRED=ON \
-            -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${FLAG_RELEASE} -DHAVE_GETPASS_R=0 -Wno-error=implicit-function-declaration" \
-            -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${FLAG_RELEASE} -DHAVE_GETPASS_R=0 -Wno-error=implicit-function-declaration" \
+            -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${FLAG_RELEASE} -Wno-error=implicit-function-declaration" \
+            -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${FLAG_RELEASE} -Wno-error=implicit-function-declaration" \
+            -DCURL_DISABLE_LIBSSH2=ON \
+            -DCURL_DISABLE_LIBPSL=ON \
             -DCMAKE_CXX_EXTENSIONS=OFF \
             -DBUILD_SHARED_LIBS=OFF \
             -DCURL_STATICLIB=ON \

--- a/apothecary/formulas/curl/curl.sh
+++ b/apothecary/formulas/curl/curl.sh
@@ -303,6 +303,7 @@ function build() {
             -DCMAKE_CXX_STANDARD_REQUIRED=ON \
             -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${FLAG_RELEASE} -Wno-error=implicit-function-declaration" \
             -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${FLAG_RELEASE} -Wno-error=implicit-function-declaration" \
+            -DHAVE_GETPASS_R=0 \
             -DCURL_DISABLE_LIBSSH2=ON \
             -DCURL_DISABLE_LIBPSL=ON \
             -DCMAKE_CXX_EXTENSIONS=OFF \

--- a/apothecary/formulas/curl/curl.sh
+++ b/apothecary/formulas/curl/curl.sh
@@ -107,7 +107,6 @@ function build() {
         LIBBROTLI_ENC_LIB="$LIBBROTLI_LIBRARY/brotlienc.lib"
         LIBBROTLI_DEC_LIB="$LIBBROTLI_LIBRARY/brotlidec.lib"
 
-
         export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig;${PKG_CONFIG_PATH};${OF_LIBS_OPENSSL}/lib/$TYPE/$PLATFORM;${ZLIB_ROOT}/lib/$TYPE/$PLATFORM;${LIBBROTLI_ROOT}/lib/$TYPE/$PLATFORM"
 
         DEFS="-DLIBRARY_SUFFIX=${ARCH} \
@@ -295,7 +294,7 @@ function build() {
             -DCMAKE_CXX_STANDARD=${CPP_STANDARD} \
             -DCMAKE_CXX_STANDARD_REQUIRED=ON \
             -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${FLAG_RELEASE} " \
-            -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${FLAG_RELEASE} " \
+            -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${FLAG_RELEASE} -DHAVE_GETPASS_R=0" \
             -DCMAKE_CXX_EXTENSIONS=OFF \
             -DBUILD_SHARED_LIBS=OFF \
             -DCURL_STATICLIB=ON \
@@ -329,8 +328,8 @@ function build() {
             -DCURL_ENABLE_SSL=${CURL_ENABLE_SSL} \
             -DCMAKE_MACOSX_BUNDLE=OFF \
             -DUSE_SECURE_TRANSPORT=${USE_SECURE_TRANSPORT} \
+            -DCURL_USE_SECTRANSP=${USE_SECURE_TRANSPORT} \
             -DUSE_NGHTTP2=OFF \
-            -DCURL_USE_SECTRANSP=OFF \
             -DCURL_DISABLE_POP3=ON \
             -DCURL_CA_FALLBACK=ON \
             -DCURL_DISABLE_IMAP=ON \

--- a/apothecary/formulas/curl/curl.sh
+++ b/apothecary/formulas/curl/curl.sh
@@ -303,6 +303,7 @@ function build() {
             -DCMAKE_CXX_STANDARD_REQUIRED=ON \
             -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${FLAG_RELEASE} -Wno-error=implicit-function-declaration" \
             -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${FLAG_RELEASE} -Wno-error=implicit-function-declaration" \
+            -DENABLE_STRICT_TRY_COMPILE=ON \
             -DHAVE_GETPASS_R=0 \
             -DCURL_DISABLE_LIBSSH2=ON \
             -DCURL_DISABLE_LIBPSL=ON \

--- a/apothecary/formulas/curl/curl.sh
+++ b/apothecary/formulas/curl/curl.sh
@@ -308,6 +308,7 @@ function build() {
             -DCURL_DISABLE_LIBPSL=ON \
             -DCMAKE_CXX_EXTENSIONS=OFF \
             -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_IGNORE_PATH=/opt/homebrew \
             -DCURL_STATICLIB=ON \
             -DBUILD_STATIC_LIBS=ON \
             -DENABLE_UNICODE=ON \

--- a/apothecary/formulas/openssl/openssl.sh
+++ b/apothecary/formulas/openssl/openssl.sh
@@ -148,6 +148,7 @@ function build() {
             ${DEFS} \
 	        -DCMAKE_INSTALL_INCLUDEDIR=include \
 	        -DCMAKE_IGNORE_PATH=/opt/homebrew \
+	        -DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON \
 		    -DCMAKE_TOOLCHAIN_FILE=$APOTHECARY_DIR/toolchains/ios.toolchain.cmake \
 			-DPLATFORM=$PLATFORM \
 			-DENABLE_BITCODE=OFF \

--- a/apothecary/formulas/openssl/openssl.sh
+++ b/apothecary/formulas/openssl/openssl.sh
@@ -6,10 +6,11 @@
 FORMULA_TYPES=( "vs" "osx" "ios" "xros" )
 FORMULA_DEPENDS=( "zlib" )
 
-VER=3.3.1
-VERDIR=3.3.1
-SHA1=7376042523b6a229bc697b8099c2af369d1a84c6
-SHA256=53e66b043322a606abf0087e7699a0e033a37fa13feb9742df35c3a33b18fb02
+VER=3.4.0
+VERDIR=3.4.0
+VER_TAG="3.4"
+SHA1=5c2f33c3f3601676f225109231142cdc30d44127
+SHA256=e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf
 
 BUILD_ID=1
 DEFINES=""
@@ -66,10 +67,14 @@ function download() {
 		downloader ${MIRROR}/source/$FILE_NAME.tar.gz.sha1
 	fi
 	CHECKSHA=$(shasum $FILE_NAME.tar.gz | awk '{print $1}')
-	FILESUM=$(head -1 $FILE_NAME.tar.gz.sha1)
-	if [[ " $CHECKSHA" != $FILESUM || $CHECKSHA != "$SHA1" ]] ;  then
-		echoError "SHA did not Verify: [$CHECKSHA] SHA on Record:[$SHA1] FILESUM=[$FILESUM]- Developer has not updated SHA or Man in the Middle Attack"
-    	exit
+
+	# Extract only the SHA value from the .sha1 file
+	FILESUM=$(awk '{print $1}' $FILE_NAME.tar.gz.sha1)
+
+	# Check if CHECKSHA matches both FILESUM and the expected SHA1
+	if [[ "$CHECKSHA" != "$FILESUM" || "$CHECKSHA" != "$SHA1" ]]; then
+	    echo "SHA did not Verify: [$CHECKSHA] SHA on Record:[$SHA1] FILESUM=[$FILESUM] - Developer has not updated SHA or Man in the Middle Attack"
+	    exit 1
     else
     	tar -xf "${FILE_NAME}.tar.gz"
 		echo "SHA for Download Verified Successfully: [$CHECKSHA] SHA on Record:[$SHA1]"
@@ -78,7 +83,7 @@ function download() {
 		rm $FILE_NAME.tar.gz.sha1
 	fi
 	# Clone the openssl-cmake repository
-	git clone --branch "3.3" --depth=1 $GIT_URL openssl_cmake_temp
+	git clone --branch $VER_TAG --depth=1 $GIT_URL openssl_cmake_temp
 
 	# Organize directories as needed
 	mkdir -p openssl
@@ -142,6 +147,7 @@ function build() {
             -DZLIB_INCLUDE_DIRS=${ZLIB_INCLUDE_DIR} \
             ${DEFS} \
 	        -DCMAKE_INSTALL_INCLUDEDIR=include \
+	        -DCMAKE_IGNORE_PATH=/opt/homebrew \
 		    -DCMAKE_TOOLCHAIN_FILE=$APOTHECARY_DIR/toolchains/ios.toolchain.cmake \
 			-DPLATFORM=$PLATFORM \
 			-DENABLE_BITCODE=OFF \


### PR DESCRIPTION
Triggered by macOS / iOS builds failing due to Runner Changes nov5th changing some preinstalled libraries.

## cURL [8.9.1 ~ 8.11.0]
- Changelog https://curl.se/ch/8.11.0.html
- Formulae - updated SHA / tag

## OpenSSL [3.3.1~3.4.0]
- https://github.com/openssl/openssl/blob/master/CHANGES.md
- Formulae: Fix for tag on cmake script / SHA (fixes nov5 changes) 
