### PR TITLE
OpenCV 4.11.0 / Assimp Static

### DIFF
--- a/.github/workflows/build-linux-cross.yml
+++ b/.github/workflows/build-linux-cross.yml
@@ -17,7 +17,7 @@ env:
   NO_FORCE: 1
   GA_CI_SECRET: ${{ secrets.CI_SECRET }}
   USE_ARTIFACT: false
-  DISABLE_WORKFLOW: "false"
+  DISABLE_WORKFLOW: "true"
 
 jobs:  
   pre-check:

--- a/.github/workflows/build-linux-rpi.yml
+++ b/.github/workflows/build-linux-rpi.yml
@@ -16,7 +16,7 @@ env:
   NO_FORCE: 1
   GA_CI_SECRET: ${{ secrets.CI_SECRET }}
   USE_ARTIFACT: false
-  DISABLE_WORKFLOW: "false"
+  DISABLE_WORKFLOW: "true"
 
 jobs:  
   pre-check:

--- a/apothecary/formulas/assimp.sh
+++ b/apothecary/formulas/assimp.sh
@@ -88,7 +88,8 @@ function build() {
             -DPLATFORM=$PLATFORM \
             -DENABLE_BITCODE=OFF \
             -DENABLE_ARC=OFF \
-            -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DCMAKE_MINIMUM_REQUIRED_VERSION=3.22 \
             -DENABLE_VISIBILITY=OFF \
             -DCMAKE_PREFIX_PATH="${LIBS_ROOT}" \
             -DZLIB_ROOT=${ZLIB_ROOT} \
@@ -119,12 +120,40 @@ function build() {
             -DCMAKE_CXX_STANDARD=${CPP_STANDARD} \
             -DCMAKE_CXX_STANDARD_REQUIRED=ON \
             -DCMAKE_CXX_EXTENSIONS=OFF \
-            -DBUILD_SHARED_LIBS=ON \
             -DASSIMP_BUILD_TESTS=0 \
             -DASSIMP_BUILD_SAMPLES=0 \
             -DASSIMP_BUILD_3MF_IMPORTER=0 \
-            -DASSIMP_WARNINGS_AS_ERRORS=OFF \
-            -DBUILD_WITH_STATIC_CRT=OFF"
+            -DASSIMP_WARNINGS_AS_ERRORS=OFF"
+
+        if [ -n "${ASSIMP_STATIC}" ] && [ "${ASSIMP_STATIC}" = "1" ]; then
+            DEFINES="${DEFINES} \
+            -DBUILD_WITH_STATIC_CRT=ON \
+            -DBUILD_SHARED_LIBS=OFF"
+        else
+            DEFINES="${DEFINES} \
+            -DBUILD_WITH_STATIC_CRT=OFF \
+            -DBUILD_SHARED_LIBS=ON"
+            cmake .. ${DEFINES} \
+            -A "${PLATFORM}" \
+            ${CMAKE_WIN_SDK} \
+            -G "${GENERATOR_NAME}" \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_INSTALL_PREFIX=Debug \
+            -DCMAKE_INSTALL_LIBDIR="lib" \
+            -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${VS_C_FLAGS} ${FLAGS_DEBUG} ${EXCEPTION_FLAGS}" \
+            -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${VS_C_FLAGS} ${FLAGS_DEBUG} ${EXCEPTION_FLAGS}" \
+            -DCMAKE_CXX_FLAGS_DEBUG="-DUSE_PTHREADS=1 ${VS_C_FLAGS} ${FLAGS_DEBUG} ${EXCEPTION_FLAGS}" \
+            -DCMAKE_C_FLAGS_DEBUG="-DUSE_PTHREADS=1 ${VS_C_FLAGS} ${FLAGS_DEBUG} ${EXCEPTION_FLAGS}" \
+            -DCMAKE_PREFIX_PATH="${LIBS_ROOT}" \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DCMAKE_MINIMUM_REQUIRED_VERSION=3.22 \
+            -DASSIMP_BUILD_ZLIB=OFF \
+            -DZLIB_ROOT=${ZLIB_ROOT} \
+            -DZLIB_INCLUDE_DIR=${ZLIB_INCLUDE_DIR} \
+            -DZLIB_LIBRARY=${ZLIB_LIBRARY}
+            cmake --build . --config Debug -j${PARALLEL_MAKE}
+            rm -f CMakeCache.txt || true
+        fi
 
         cmake .. ${DEFINES} \
             -A "${PLATFORM}" \
@@ -138,30 +167,14 @@ function build() {
             -DCMAKE_CXX_FLAGS_RELEASE="-DUSE_PTHREADS=1 ${VS_C_FLAGS} ${FLAGS_RELEASE} ${EXCEPTION_FLAGS}" \
             -DCMAKE_C_FLAGS_RELEASE="-DUSE_PTHREADS=1 ${VS_C_FLAGS} ${FLAGS_RELEASE} ${EXCEPTION_FLAGS}" \
             -DCMAKE_PREFIX_PATH="${LIBS_ROOT}" \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DCMAKE_MINIMUM_REQUIRED_VERSION=3.22 \
             -DASSIMP_BUILD_ZLIB=OFF \
             -DZLIB_ROOT=${ZLIB_ROOT} \
             -DZLIB_INCLUDE_DIR=${ZLIB_INCLUDE_DIR} \
             -DZLIB_LIBRARY=${ZLIB_LIBRARY}
         cmake --build . --config Release -j${PARALLEL_MAKE}
 
-        cmake .. ${DEFINES} \
-            -A "${PLATFORM}" \
-            ${CMAKE_WIN_SDK} \
-            -G "${GENERATOR_NAME}" \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_INSTALL_PREFIX=Debug \
-            -DCMAKE_INSTALL_LIBDIR="lib" \
-            -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 ${VS_C_FLAGS} ${FLAGS_DEBUG} ${EXCEPTION_FLAGS}" \
-            -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 ${VS_C_FLAGS} ${FLAGS_DEBUG} ${EXCEPTION_FLAGS}" \
-            -DCMAKE_CXX_FLAGS_DEBUG="-DUSE_PTHREADS=1 ${VS_C_FLAGS} ${FLAGS_DEBUG} ${EXCEPTION_FLAGS}" \
-            -DCMAKE_C_FLAGS_DEBUG="-DUSE_PTHREADS=1 ${VS_C_FLAGS} ${FLAGS_DEBUG} ${EXCEPTION_FLAGS}" \
-            -DCMAKE_PREFIX_PATH="${LIBS_ROOT}" \
-            -DASSIMP_BUILD_ZLIB=OFF \
-            -DZLIB_ROOT=${ZLIB_ROOT} \
-            -DZLIB_INCLUDE_DIR=${ZLIB_INCLUDE_DIR} \
-            -DZLIB_LIBRARY=${ZLIB_LIBRARY}
-        cmake --build . --config Debug -j${PARALLEL_MAKE}
-        rm -f CMakeCache.txt || true
         cd ..
         echo "--------------------"
         echo "Completed Assimp for $TYPE | $ARCH | $VS_VER"
@@ -211,14 +224,14 @@ function build() {
             -DANDROID_NDK_ROOT=$ANDROID_NDK_ROOT \
             -DCMAKE_PREFIX_PATH="${LIBS_ROOT}" \
             -DBUILD_SHARED_LIBS=OFF \
-            -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
             -DCMAKE_MINIMUM_REQUIRED_VERSION=3.22 \
             -DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 -fvisibility-inlines-hidden -std=c++${CPP_STANDARD} -frtti ${FLAG_RELEASE}" \
             -DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 -fvisibility-inlines-hidden -std=c${C_STANDARD} -Wno-implicit-function-declaration -frtti ${FLAG_RELEASE}" \
             -DENABLE_VISIBILITY=OFF \
             -DCMAKE_VERBOSE_MAKEFILE=${VERBOSE_MAKEFILE} \
             -DCMAKE_CXX_EXTENSIONS=OFF \
-            -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
             -DZLIB_ROOT=${ZLIB_ROOT} \
             -DZLIB_ROOT=${ZLIB_ROOT} \
             -DZLIB_LIBRARY=${ZLIB_LIBRARY} \
@@ -257,6 +270,7 @@ function build() {
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INCLUDE_OUTPUT_DIRECTORY=include \
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DCMAKE_MINIMUM_REQUIRED_VERSION=3.22 \
             -DCMAKE_INSTALL_INCLUDEDIR=include \
             -DCMAKE_C_STANDARD=${C_STANDARD} \
             -DCMAKE_CXX_STANDARD=${CPP_STANDARD} \

--- a/apothecary/formulas/assimp.sh
+++ b/apothecary/formulas/assimp.sh
@@ -316,13 +316,19 @@ function copy() {
     if [ "$TYPE" == "vs" ]; then
         cp -v -r build_${TYPE}_${PLATFORM}/include/* $1/include
         mkdir -p $1/lib/$TYPE/$PLATFORM/
-        mkdir -p $1/lib/$TYPE/$PLATFORM/Debug
-        mkdir -p $1/lib/$TYPE/$PLATFORM/Release
-        cp -v "build_${TYPE}_${PLATFORM}/bin/Release/assimp-vc${VC_VERSION}-mt.dll" $1/lib/$TYPE/$PLATFORM/Release/assimp-vc${VC_VERSION}-mt.dll
-        cp -v "build_${TYPE}_${PLATFORM}/bin/Debug/assimp-vc${VC_VERSION}-mtd.dll" $1/lib/$TYPE/$PLATFORM/Debug/assimp-vc${VC_VERSION}-mtd.dll
-        cp -v "build_${TYPE}_${PLATFORM}/lib/Release/assimp-vc${VC_VERSION}-mt.lib" $1/lib/$TYPE/$PLATFORM/Release/libassimp.lib
-        cp -v "build_${TYPE}_${PLATFORM}/lib/Debug/assimp-vc${VC_VERSION}-mtd.lib" $1/lib/$TYPE/$PLATFORM/Debug/libassimpD.lib
-        secure $1/lib/$TYPE/$PLATFORM/libassimp.a assimp.pkl
+        if [ -n "${ASSIMP_STATIC}" ] && [ "${ASSIMP_STATIC}" = "1" ]; then
+            cp -v "build_${TYPE}_${PLATFORM}/lib/Release/assimp-vc${VC_VERSION}-mt.lib" $1/lib/$TYPE/$PLATFORM/libassimp.lib
+            secure $1/lib/$TYPE/$PLATFORM/libassimp.lib assimp.pkl
+        else
+            mkdir -p $1/lib/$TYPE/$PLATFORM/Debug
+            mkdir -p $1/lib/$TYPE/$PLATFORM/Release
+            cp -v "build_${TYPE}_${PLATFORM}/bin/Release/assimp-vc${VC_VERSION}-mt.dll" $1/lib/$TYPE/$PLATFORM/Release/assimp-vc${VC_VERSION}-mt.dll
+            cp -v "build_${TYPE}_${PLATFORM}/bin/Debug/assimp-vc${VC_VERSION}-mtd.dll" $1/lib/$TYPE/$PLATFORM/Debug/assimp-vc${VC_VERSION}-mtd.dll
+            cp -v "build_${TYPE}_${PLATFORM}/lib/Debug/assimp-vc${VC_VERSION}-mtd.lib" $1/lib/$TYPE/$PLATFORM/Debug/libassimpD.lib
+            cp -v "build_${TYPE}_${PLATFORM}/lib/Release/assimp-vc${VC_VERSION}-mt.lib" $1/lib/$TYPE/$PLATFORM/Release/libassimp.lib
+            secure $1/lib/$TYPE/$PLATFORM/Release/libassimp.lib assimp.pkl
+        fi
+
     elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos)$ ]]; then
         cp -v -r build_${TYPE}_${PLATFORM}/include/* $1/include
         mkdir -p $1/lib/$TYPE/$PLATFORM/

--- a/apothecary/formulas/assimp.sh
+++ b/apothecary/formulas/assimp.sh
@@ -125,7 +125,7 @@ function build() {
             -DASSIMP_BUILD_3MF_IMPORTER=0 \
             -DASSIMP_WARNINGS_AS_ERRORS=OFF"
 
-        if [ -n "${ASSIMP_STATIC}" ] && [ "${ASSIMP_STATIC}" = "1" ]; then
+        if [ "${ASSIMP_STATIC:-0}" = "1" ]; then
             DEFINES="${DEFINES} \
             -DBUILD_WITH_STATIC_CRT=ON \
             -DUSE_STATIC_CRT=ON \
@@ -316,7 +316,7 @@ function copy() {
     if [ "$TYPE" == "vs" ]; then
         cp -v -r build_${TYPE}_${PLATFORM}/include/* $1/include
         mkdir -p $1/lib/$TYPE/$PLATFORM/
-        if [ -n "${ASSIMP_STATIC}" ] && [ "${ASSIMP_STATIC}" = "1" ]; then
+       if [ "${ASSIMP_STATIC:-0}" = "1" ]; then
             cp -v "build_${TYPE}_${PLATFORM}/lib/Release/assimp-vc${VC_VERSION}-mt.lib" $1/lib/$TYPE/$PLATFORM/libassimp.lib
             secure $1/lib/$TYPE/$PLATFORM/libassimp.lib assimp.pkl
         else

--- a/apothecary/formulas/assimp.sh
+++ b/apothecary/formulas/assimp.sh
@@ -128,7 +128,11 @@ function build() {
         if [ -n "${ASSIMP_STATIC}" ] && [ "${ASSIMP_STATIC}" = "1" ]; then
             DEFINES="${DEFINES} \
             -DBUILD_WITH_STATIC_CRT=ON \
+            -DUSE_STATIC_CRT=ON \
             -DBUILD_SHARED_LIBS=OFF"
+            if [ $MULTITHREADED_TYPE == "MD" ]; then
+                sed -i 's/\/MT/\/MD/g; s/\/MTd/\/MDd/g' ../CMakeLists.txt
+            fi
         else
             DEFINES="${DEFINES} \
             -DBUILD_WITH_STATIC_CRT=OFF \

--- a/apothecary/formulas/libpng/libpng.sh
+++ b/apothecary/formulas/libpng/libpng.sh
@@ -150,16 +150,17 @@ function build() {
         ZLIB_INCLUDE_DIR="$LIBS_ROOT/zlib/include"
         ZLIB_LIBRARY="$LIBS_ROOT/zlib/lib/$TYPE/$PLATFORM/zlib.lib"
 
-        if [ "$PLATFORM" == "ARM64EC" ]; then
-            HARDWARE_OPTIMIZATIONS="OFF"
-        else
-            HARDWARE_OPTIMIZATIONS="ON"
-        fi
+        HARDWARE_OPTIMIZATIONS=on
+        # if [ "$PLATFORM" == "ARM64EC" ]; then
+        #     HARDWARE_OPTIMIZATIONS="OFF"
+        # else
+        #     HARDWARE_OPTIMIZATIONS="ON"
+        # fi
 
         if [[ ${ARCH} == "arm64ec" || "${ARCH}" == "arm64" ]]; then
-            EXTRA_DEFS="-DPNG_ARM_NEON=ON"
+            EXTRA_DEFS="-DPNG_ARM_NEON=on"
         else
-            EXTRA_DEFS="-DPNG_ARM_NEON=OFF"
+            EXTRA_DEFS="-DPNG_ARM_NEON=off -DPNG_INTEL_SS=on"
         fi
 
 

--- a/apothecary/formulas/libpng/libpng.sh
+++ b/apothecary/formulas/libpng/libpng.sh
@@ -156,9 +156,17 @@ function build() {
             HARDWARE_OPTIMIZATIONS="ON"
         fi
 
+        if [[ ${ARCH} == "arm64ec" || "${ARCH}" == "arm64" ]]; then
+            EXTRA_DEFS="-DPNG_ARM_NEON=ON"
+        else
+            EXTRA_DEFS="-DPNG_ARM_NEON=OFF"
+        fi
+
+
         env CXXFLAGS="-DUSE_PTHREADS=1 ${VS_C_FLAGS} ${FLAGS_RELEASE} ${CALLING_CONVENTION}"
         env CFLAGS="-DUSE_PTHREADS=1 ${VS_C_FLAGS} ${FLAGS_RELEASE} ${CALLING_CONVENTION}"
         cmake .. ${DEFINES} \
+            ${EXTRA_DEFS} \
             -B . \
             -DZLIB_ROOT=${ZLIB_ROOT} \
             -DZLIB_LIBRARY=${ZLIB_LIBRARY} \

--- a/apothecary/formulas/libpng/libpng.sh
+++ b/apothecary/formulas/libpng/libpng.sh
@@ -9,7 +9,7 @@ FORMULA_DEPENDS=("zlib")
 # define the version
 MAJOR_VER=16
 VER=1.6.43
-BUILD_ID=1
+BUILD_ID=2
 DEFINES=""
 
 # tools for git use

--- a/apothecary/formulas/opencv/opencv.sh
+++ b/apothecary/formulas/opencv/opencv.sh
@@ -314,9 +314,9 @@ function build() {
                 -DCV_DISABLE_OPTIMIZATION=OFF"
 
         if [[ ${ARCH} == "arm64ec" || "${ARCH}" == "arm64" ]]; then
-            EXTRA_DEFS="-DCV_ENABLE_INTRINSICS=OFF -DBUILD_opencv_rgbd=OFF -DPNG_ARM_NEON=ON"
+            EXTRA_DEFS="-DCV_ENABLE_INTRINSICS=OFF -DBUILD_opencv_rgbd=OFF -DPNG_ARM_NEON=on"
         else
-            EXTRA_DEFS="-DCV_ENABLE_INTRINSICS=ON -DPNG_ARM_NEON=OFF"
+            EXTRA_DEFS="-DCV_ENABLE_INTRINSICS=ON -DPNG_ARM_NEON=off -DPNG_INTEL_SS=on"
         fi
 
         cmake .. ${DEFINES} \

--- a/apothecary/formulas/opencv/opencv.sh
+++ b/apothecary/formulas/opencv/opencv.sh
@@ -10,8 +10,8 @@ FORMULA_TYPES=("osx" "ios" "catos" "xros" "tvos" "vs" "android" "emscripten")
 FORMULA_DEPENDS=("zlib" "libpng")
 
 # define the version
-VER=4.10.0
-BUILD_ID=3
+VER=4.11.0
+BUILD_ID=4
 DEFINES=""
 FRAMEWORKS=""
 

--- a/apothecary/formulas/opencv/opencv.sh
+++ b/apothecary/formulas/opencv/opencv.sh
@@ -314,9 +314,9 @@ function build() {
                 -DCV_DISABLE_OPTIMIZATION=OFF"
 
         if [[ ${ARCH} == "arm64ec" || "${ARCH}" == "arm64" ]]; then
-            EXTRA_DEFS="-DCV_ENABLE_INTRINSICS=OFF -DBUILD_opencv_rgbd=OFF"
+            EXTRA_DEFS="-DCV_ENABLE_INTRINSICS=OFF -DBUILD_opencv_rgbd=OFF -DPNG_ARM_NEON=ON"
         else
-            EXTRA_DEFS="-DCV_ENABLE_INTRINSICS=ON"
+            EXTRA_DEFS="-DCV_ENABLE_INTRINSICS=ON -DPNG_ARM_NEON=OFF"
         fi
 
         cmake .. ${DEFINES} \


### PR DESCRIPTION
OpenCV 4.10.0 -> 4.11.0
LibPNG fixes for Neon / SS Windows
Assimp - Allow Static build - release mode - static CRT (modified cmake to allow MD / or Multithreaded type) 