### PR TITLE
Updates Depends - LibPNG / Brotli compression (zlib)

### DIFF
--- a/apothecary/formulas/brotli.sh
+++ b/apothecary/formulas/brotli.sh
@@ -9,8 +9,8 @@ FORMULA_TYPES=("osx" "vs" "ios" "watchos" "catos" "xros" "tvos" "linux" "android
 FORMULA_DEPENDS=()
 
 # define the version
-VER=1.1.0
-BUILD_ID=1
+VER=1.2.0
+BUILD_ID=2
 DEFINES=""
 
 # tools for git use
@@ -238,7 +238,7 @@ function build() {
         cd "build_${TYPE}_${PLATFORM}"
         rm -f CMakeCache.txt *.a *.o *.a
 
-        $EMSDK/upstream/emscripten/emcmake cmake .. \
+        $EMSDK/upstream/emscripten/emcmake .. \
             cmake .. ${DEFINES} \
             -DCMAKE_PREFIX_PATH="${LIBS_ROOT}" \
             -DCMAKE_TOOLCHAIN_FILE=$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake \

--- a/apothecary/formulas/brotli.sh
+++ b/apothecary/formulas/brotli.sh
@@ -238,8 +238,8 @@ function build() {
         cd "build_${TYPE}_${PLATFORM}"
         rm -f CMakeCache.txt *.a *.o *.a
 
-        $EMSDK/upstream/emscripten/emcmake .. \
-            cmake .. ${DEFINES} \
+        $EMSDK/upstream/emscripten/emcmake cmake .. \
+            ${DEFINES} \
             -DCMAKE_PREFIX_PATH="${LIBS_ROOT}" \
             -DCMAKE_TOOLCHAIN_FILE=$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake \
             -DCMAKE_C_STANDARD=${C_STANDARD} \

--- a/apothecary/formulas/libpng/libpng.sh
+++ b/apothecary/formulas/libpng/libpng.sh
@@ -8,8 +8,8 @@ FORMULA_DEPENDS=("zlib")
 
 # define the version
 MAJOR_VER=16
-VER=1.6.43
-BUILD_ID=3
+VER=1.6.58
+BUILD_ID=4
 DEFINES=""
 
 # tools for git use


### PR DESCRIPTION
## LibPNG from 1.6.41 to 1.6.58

### Security Fixes in libpng (from 1.6.41 to 1.6.58)

| Version    | Release Date   | CVEs Fixed                                      | Severity   | Description |
|------------|----------------|-------------------------------------------------|------------|-------------|
| **1.6.51** | Nov 2025      | CVE-2025-64505, CVE-2025-64506, CVE-2025-64720, CVE-2025-65018 | High      | Multiple heap buffer overflows and out-of-bounds reads in the simplified API and `png_do_quantize` |
| **1.6.52** | Dec 2025      | **CVE-2025-66293**                             | High      | Out-of-bounds read (up to 1012 bytes) in simplified API (palette + gamma + partial transparency) |
| **1.6.54** | Jan 2026      | CVE-2026-22695, **CVE-2026-22801**            | Moderate  | Issues with interlaced 16-bit images and negative/large row strides |
| **1.6.55** | Feb 2026      | **CVE-2026-25646**                             | **High**  | ~30-year-old heap buffer overflow in `png_set_quantize()` / `png_set_dither()` |
| **1.6.56** | Mar 2026      | **CVE-2026-33416** (High)<br>**CVE-2026-33636** (High) | **High**  | Use-after-free in palette/transparency handling + out-of-bounds in ARM Neon palette expansion |
| **1.6.57** | Apr 2026      | **CVE-2026-34757**                             | Medium    | Use-after-free regression in chunk setter API + integer overflow in rowbytes calculation |
| **1.6.58** | Apr 2026      | Final cleanups + minor fixes                   | —         | Latest stable release (includes all fixes above) |

**Note:** Several of these vulnerabilities had existed for **25–30 years** and were reachable with **valid PNG files**.


### Security Fixes in Brotli (from 1.1.0 to 1.2.0)

| Version    | Release Date      | CVEs Fixed        | Severity | Description |
|------------|-------------------|-------------------|----------|-------------|
| **1.2.0**  | Oct 27, 2025     | **CVE-2025-6176** | High     | Decompression Bomb Denial-of-Service (DoS). Brotli could produce extremely high compression ratios on certain inputs (e.g. zero-filled data), leading to excessive memory use during decompression. Fixed by adding `Decompressor::can_accept_more_data()` method and optional `output_buffer_limit` argument to `Decompressor::process()` in the Python bindings. |

**Note:** This was the only security-related change between 1.1.0 and 1.2.0. The vulnerability affected all versions up to and including 1.1.0 and was reachable with valid (but maliciously crafted) compressed data.