### PR TITLE
Fixed missing videoInput.a in non-standard environments.

### DIFF
--- a/.github/workflows/auto-retry.yml
+++ b/.github/workflows/auto-retry.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Re-run failed workflow runs on the current branch
         uses: actions/github-script@v6
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
         with:
           script: |
             // Remove 'refs/heads/' from the branch name

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -164,7 +164,7 @@ jobs:
         run: ls -lah out/
 
       - name: Package Binaries for Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') && env.USE_ARTIFACT == 'true'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') && env.USE_ARTIFACT == 'true'
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: |
           scripts/artifact/artifact.sh
@@ -172,7 +172,7 @@ jobs:
           ARCH: ${{ env.ARCH }}
 
       - name: Upload Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') && env.USE_ARTIFACT == 'true'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') && env.USE_ARTIFACT == 'true'
         uses: actions/upload-artifact@v7.0.0
         with:
           name: libs-${{ env.RELEASE }}-android-${{ env.ARCH }}
@@ -180,7 +180,7 @@ jobs:
           retention-days: 31
 
       - name: Remove .tar.bz2 files
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
         run: |
           echo "Removing .tar.bz2 files from out/ directory..."
           rm -f out/*.tar.bz2
@@ -193,13 +193,13 @@ jobs:
           ./scripts/summary.sh
 
       - name: Package
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: scripts/package.sh
         env:
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Update Release emscripten
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: softprops/action-gh-release@v2.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -81,7 +81,7 @@ jobs:
               fs.mkdirSync(outputDir);
             }
             const artifacts = await github.rest.actions.listArtifactsForRepo({
-              owner: 'openframeworks',
+              owner: context.repo.owner,
               repo: 'apothecary',
               sort: 'created_at',
               direction: 'desc',

--- a/.github/workflows/build-catos.yml
+++ b/.github/workflows/build-catos.yml
@@ -83,21 +83,21 @@ jobs:
       - name: List output directory
         run: ls -lah out/
       - name: Package Binaries for Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: scripts/artifact/artifact.sh
         env:
           BUNDLE: ${{ matrix.bundle }}
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Upload binaries as Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: actions/upload-artifact@v7.0.0
         with:
           name: libs-mac-cataylst-${{ env.TARGET }}-${{ matrix.bundle }}
           path: out/openFrameworksLibs_${{ env.release }}_${{ env.TARGET }}_${{ matrix.bundle }}.tar.bz2
           retention-days: 30
       - name: Remove .tar.bz2 files
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         run: |
           echo "Removing .tar.bz2 files from out/ directory..."
           rm -f out/*.tar.bz2
@@ -110,7 +110,7 @@ jobs:
           BUNDLE: ${{ matrix.bundle }}
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
 #      - name: Package
-#        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+#        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
       
 #        working-directory: ${{ env.GITHUB_WORKSPACE }}
 #        run: scripts/package.sh
@@ -118,7 +118,7 @@ jobs:
 #          BUNDLE: ${{ matrix.bundle }}
 #          GA_CI_SECRET: ${{ secrets.CI_SECRET }}
 #      - name: Update Release XCFramework
-#        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+#        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
       
 #        uses: johnwbyrd/update-release@v1.0.0
 #        with:

--- a/.github/workflows/build-emscripten.yml
+++ b/.github/workflows/build-emscripten.yml
@@ -99,7 +99,7 @@ jobs:
               fs.mkdirSync(outputDir);
             }
             const artifacts = await github.rest.actions.listArtifactsForRepo({
-              owner: 'openframeworks',
+              owner: context.repo.owner,
               repo: 'apothecary',
               sort: 'created_at',
               direction: 'desc',

--- a/.github/workflows/build-emscripten.yml
+++ b/.github/workflows/build-emscripten.yml
@@ -177,7 +177,7 @@ jobs:
           ARCH: ${{ env.ARCH }}
     
       - name: Package Binaries for Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') && env.USE_ARTIFACT == 'true'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') && env.USE_ARTIFACT == 'true'
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: |
           scripts/artifact/artifact.sh
@@ -185,7 +185,7 @@ jobs:
           ARCH: ${{ env.ARCH }}
 
       - name: Upload Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') && env.USE_ARTIFACT == 'true'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') && env.USE_ARTIFACT == 'true'
         uses: actions/upload-artifact@v7.0.0
         with:
           name: libs-${{ env.RELEASE }}-emscripten-${{ env.ARCH }}
@@ -193,7 +193,7 @@ jobs:
           retention-days: 31
 
       - name: Remove .tar.bz2 files
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
         run: |
           echo "Removing .tar.bz2 files from out/ directory..."
           rm -f out/*.tar.bz2
@@ -201,7 +201,7 @@ jobs:
           echo "Cleanup complete."
 
       - name: Package
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: |
           scripts/package.sh
@@ -213,7 +213,7 @@ jobs:
         run: ls -lah out/
 
       - name: Update Release
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: softprops/action-gh-release@v2.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -221,12 +221,12 @@ jobs:
           files: out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ env.ARCH }}.tar.bz2
 
       - name: Clean for
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push'
+        if: github.event_name == 'push'
         run: |
           rm -f out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ env.ARCH }}.tar.bz2
 
       - name: Package
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: |
           scripts/package-individual.sh
@@ -235,7 +235,7 @@ jobs:
           ARCH: ${{ env.ARCH }}
 
       - name: Upload to GitHub Release
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: softprops/action-gh-release@v2.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -195,20 +195,20 @@ jobs:
       - name: List output directory2
         run: ls -lah out/
       - name: Package Binaries for Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: scripts/artifact/artifact.sh
         env:
           BUNDLE: ${{ matrix.bundle }}
       - name: Upload binaries as Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: actions/upload-artifact@v7.0.0
         with:
           name: libs-${{ env.RELEASE }}-${{ env.TARGET }}-${{ matrix.bundle }}
           path: out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ matrix.bundle }}.tar.bz2
           retention-days: 31
       - name: Remove .tar.bz2 files
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         run: |
           echo "Removing .tar.bz2 files from out/ directory..."
           rm -f out/*.tar.bz2
@@ -220,13 +220,13 @@ jobs:
         env:
           BUNDLE: ${{ matrix.bundle }}
       - name: Package
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: scripts/package.sh
         env:
           BUNDLE: ${{ matrix.bundle }}
       - name: Update Release arm64
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: softprops/action-gh-release@v2.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -236,7 +236,7 @@ jobs:
   wait-for-workflows:
     runs-on: [ubuntu-latest]
     needs: build-ios-platforms
-    # if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+    # if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
     steps:
     # - name: Wait build-ios
     #   uses: NathanFirmo/wait-for-other-action@v1.0.4
@@ -274,7 +274,7 @@ jobs:
     env:
       DEVELOPER_DIR: "/Applications/Xcode_16.2.app/Contents/Developer"
       TARGET: "macos"
-    if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
     steps:
       - name: Determine Release
         id: vars
@@ -413,21 +413,21 @@ jobs:
         env:
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Update Release macOS 1
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: softprops/action-gh-release@v2.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.RELEASE }}
           files: xout_1/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_1.tar.bz2
       - name: Update Release macOS 2
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: softprops/action-gh-release@v2.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.RELEASE }}
           files: xout_2/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_2.tar.bz2
       - name: Update Release macOS 3
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: softprops/action-gh-release@v2.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -87,7 +87,7 @@ jobs:
             try {
               console.log("Fetching artifacts...");
               const artifacts = await github.rest.actions.listArtifactsForRepo({
-                owner: 'openframeworks',
+                owner: context.repo.owner,
                 repo: 'apothecary',
                 sort: 'created_at',
                 direction: 'desc',
@@ -309,7 +309,7 @@ jobs:
 
             // List all artifacts for the repository
             const artifacts = await github.rest.actions.listArtifactsForRepo({
-              owner: 'openframeworks',
+              owner: context.repo.owner,
               repo: 'apothecary',
               sort: 'created_at',
               direction: 'desc',

--- a/.github/workflows/build-linux-cross.yml
+++ b/.github/workflows/build-linux-cross.yml
@@ -80,7 +80,7 @@ jobs:
       env:
         BUNDLE: ${{ matrix.bundle }}
     - name: Package
-      if: (github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding'))
+      if: (github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding'))
       working-directory: ${{ env.GITHUB_WORKSPACE }}
       run: scripts/package.sh
       env:
@@ -88,7 +88,7 @@ jobs:
     - name: List output directory
       run: ls -lah out/
     - name: Update GitHub Release
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+      if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
       uses: softprops/action-gh-release@v2.6.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-linux-rpi.yml
+++ b/.github/workflows/build-linux-rpi.yml
@@ -101,7 +101,7 @@ jobs:
         run: ./scripts/${{ env.TARGET }}/${{ env.DISTRO }}/${{ env.ARCH }}/build.sh
 
       - name: Package
-        #if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        #if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: scripts/package.sh
         env:
@@ -113,7 +113,7 @@ jobs:
         run: ls -lah out/
 
       - name: Update Release
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: softprops/action-gh-release@v2.6.1
         env:
           GCC: "_${{ matrix.CROSS_CPU }}_${{ matrix.CROSS_OS }}"
@@ -167,7 +167,7 @@ jobs:
   #       run: ./scripts/${{ env.TARGET }}/${{ env.DISTRO }}/${{ env.ARCH }}/build.sh
 
   #     - name: Package
-  #       #if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+  #       #if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
   #       working-directory: ${{ env.GITHUB_WORKSPACE }}
   #       run: scripts/package.sh
   #       env:
@@ -179,7 +179,7 @@ jobs:
   #       run: ls -lah out/
 
   #     - name: Update Release armv6l
-  #       if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+  #       if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
   #       uses: softprops/action-gh-release@v2.6.1
   #       with:
   #         token: ${{ secrets.GITHUB_TOKEN }}
@@ -254,7 +254,7 @@ jobs:
   #       run: ./scripts/${{ env.TARGET }}/${{ env.DISTRO }}/${{ env.ARCH }}/build.sh
 
   #     - name: Package
-  #       #if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+  #       #if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
   #       working-directory: ${{ env.GITHUB_WORKSPACE }}
   #       run: scripts/package.sh
   #       env:
@@ -266,7 +266,7 @@ jobs:
   #       run: ls -lah out/
 
   #     - name: Update Release
-  #       if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+  #       if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
   #       uses: softprops/action-gh-release@v2.6.1
   #       with:
   #         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-linux64.yml
+++ b/.github/workflows/build-linux64.yml
@@ -90,7 +90,7 @@ jobs:
     #   run: ./apothecary/apothecary -tlinux -a${{ env.ARCH }} update poco
 
     - name: Package
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+      if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
       working-directory: ${{ env.GITHUB_WORKSPACE }}
       run: scripts/package.sh
       env:
@@ -111,7 +111,7 @@ jobs:
         ./scripts/summary.sh
       
     - name: Update Release 64
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+      if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
       uses: softprops/action-gh-release@v2.6.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -120,12 +120,12 @@ jobs:
         files: out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ env.ARCH }}_${{ env.GCC }}.tar.bz2
 
     - name: Clean
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push'
+      if: github.event_name == 'push'
       run: |
         rm -f out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ env.ARCH }}_${{ env.GCC }}.tar.bz2
 
     - name: Package Split
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
       working-directory: ${{ env.GITHUB_WORKSPACE }}
       run: |
         scripts/package-individual.sh
@@ -137,14 +137,14 @@ jobs:
       run: ls -lah out/
 
     - name: Clean before latest-modular upload
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') &&
+      if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') &&
           env.GCC == 'gcc14'
       run: |
         echo "Cleaning any existing openFrameworksLibs* files before latest-modular upload..."
         rm -f out/openFrameworksLibs*.tar.bz2
 
     - name: Upload to GitHub Release
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') &&
+      if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') &&
           env.GCC == 'gcc14'
       uses: softprops/action-gh-release@v2.6.1
       with:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -164,14 +164,14 @@ jobs:
       #   run: ./apothecary/apothecary -tosx -ax86_64 update poco
 
       - name: Package Binaries for Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: scripts/artifact/artifact.sh
         env:
           BUNDLE: ${{ matrix.bundle }}
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Upload binaries as Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: actions/upload-artifact@v7.0.0
         with:
           name: libs-${{ env.RELEASE }}-${{ env.TARGET }}-${{ matrix.bundle }}
@@ -179,7 +179,7 @@ jobs:
           retention-days: 31
 
       - name: Remove .tar.bz2 files
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' )
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' )
         run: |
           echo "Removing .tar.bz2 files from out/ directory..."
           rm -f out/*.tar.bz2
@@ -193,7 +193,7 @@ jobs:
           BUNDLE: ${{ matrix.bundle }}
 
       - name: Package Individual Modular Libraries (macOS)
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/')) && matrix.bundle == 3
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/')) && matrix.bundle == 3
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: |
           scripts/package-individual.sh
@@ -201,12 +201,12 @@ jobs:
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
 
       - name: List output directory before modular upload
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/')) && matrix.bundle == 3
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/')) && matrix.bundle == 3
         run: ls -lah xout/
 
       # ── Clean before latest-modular upload (macOS) ─────────────────────────
       - name: Clean before latest-modular upload
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') && matrix.bundle == 3
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') && matrix.bundle == 3
         run: |
           echo "🧹 Cleaning any existing openFrameworksLibs* files before latest-modular upload..."
           rm -f xout/openFrameworksLibs*.tar.bz2
@@ -214,7 +214,7 @@ jobs:
           ls -lah xout/
 
       - name: Upload to GitHub Release (latest-modular)
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') && matrix.bundle == 3
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') && matrix.bundle == 3
         uses: softprops/action-gh-release@v2.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -222,7 +222,7 @@ jobs:
           files: xout/*.tar.bz2
 
       - name: Remove .tar.bz2 files
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' )
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' )
         run: |
           echo "Removing .tar.bz2 files from out/ directory..."
           rm -f out/*.tar.bz2
@@ -230,13 +230,13 @@ jobs:
           echo "Cleanup complete."
 
       - name: Package final
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: scripts/package.sh
         env:
           BUNDLE: ${{ matrix.bundle }}
       - name: Update Release XCFramework
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: softprops/action-gh-release@v2.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -77,7 +77,7 @@ jobs:
             }
             // https://api.github.com/repos/openframeworks/apothecary/actions/artifacts?per_page=250
             const artifacts = await github.rest.actions.listArtifactsForRepo({
-              owner: 'openframeworks',
+              owner: context.repo.owner,
               repo: 'apothecary',
               sort: 'created_at',
               direction: 'desc',

--- a/.github/workflows/build-msys2.yml
+++ b/.github/workflows/build-msys2.yml
@@ -109,7 +109,7 @@ jobs:
         working-directory: ${{env.GITHUB_WORKSPACE}}
         run: scripts/build.sh
       - name: Package
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: scripts/package.sh
         env:
@@ -117,7 +117,7 @@ jobs:
       - name: List output directory2
         run: ls -lah out/
       - name: Update Release
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: softprops/action-gh-release@v2.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-tvos.yml
+++ b/.github/workflows/build-tvos.yml
@@ -82,7 +82,7 @@ jobs:
               fs.mkdirSync(outputDir);
             }
             const artifacts = await github.rest.actions.listArtifactsForRepo({
-              owner: 'openframeworks',
+              owner: context.repo.owner,
               repo: 'apothecary',
               sort: 'created_at',
               direction: 'desc',

--- a/.github/workflows/build-tvos.yml
+++ b/.github/workflows/build-tvos.yml
@@ -168,21 +168,21 @@ jobs:
           BUNDLE: ${{ matrix.bundle }}
           ARCH: SIM_arm64
       - name: Package Binaries for Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: scripts/artifact/artifact.sh
         env:
           BUNDLE: ${{ matrix.bundle }}
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Upload binaries as Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
         uses: actions/upload-artifact@v7.0.0
         with:
           name: libs-${{ env.RELEASE }}-${{ env.TARGET }}-${{ matrix.bundle }}
           path: out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ matrix.bundle }}.tar.bz2
           retention-days: 31
       - name: Remove .tar.bz2 files
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
         run: |
           echo "Removing .tar.bz2 files from out/ directory..."
           rm -f out/*.tar.bz2
@@ -195,14 +195,14 @@ jobs:
           BUNDLE: ${{ matrix.bundle }}
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Package
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: scripts/package.sh
         env:
           BUNDLE: ${{ matrix.bundle }}
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Update Release XCFramework
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: softprops/action-gh-release@v2.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-vs2022-arm64.yml
+++ b/.github/workflows/build-vs2022-arm64.yml
@@ -192,13 +192,13 @@ jobs:
       env:
         BUNDLE: ${{ matrix.bundle }}
     - name: Package
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
       working-directory: ${{ env.GITHUB_WORKSPACE }}
       run: scripts/package.sh
       env:
         BUNDLE: ${{ matrix.bundle }}
     - name: Upload binaries as Artifact
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' )
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' )
       uses: actions/upload-artifact@v7.0.0
       env:
         release: ${{ env.RELEASE }}
@@ -207,7 +207,7 @@ jobs:
         path: out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ env.ARCH }}_${{ matrix.bundle }}.zip
         retention-days: 31
     - name: Update Release ARM64
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+      if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
       uses: softprops/action-gh-release@v2.6.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-vs2022-arm64.yml
+++ b/.github/workflows/build-vs2022-arm64.yml
@@ -108,7 +108,7 @@ jobs:
 
           // List all artifacts for the repository
           const artifacts = await github.rest.actions.listArtifactsForRepo({
-              owner: 'openframeworks',
+              owner: context.repo.owner,
               repo: 'apothecary',
               sort: 'created_at',
               direction: 'desc',

--- a/.github/workflows/build-vs2022-arm64ec.yml
+++ b/.github/workflows/build-vs2022-arm64ec.yml
@@ -111,7 +111,7 @@ jobs:
 
           // List all artifacts for the repository
           const artifacts = await github.rest.actions.listArtifactsForRepo({
-              owner: 'openframeworks',
+              owner: context.repo.owner,
               repo: 'apothecary',
               sort: 'created_at',
               direction: 'desc',

--- a/.github/workflows/build-vs2022-arm64ec.yml
+++ b/.github/workflows/build-vs2022-arm64ec.yml
@@ -196,12 +196,12 @@ jobs:
         BUNDLE: ${{ matrix.bundle }}
     - name: Package
       working-directory: ${{ env.GITHUB_WORKSPACE }}
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
       run: scripts/package.sh
       env:
         BUNDLE: ${{ matrix.bundle }}
     - name: Upload binaries as Artifact
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' )
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' )
       uses: actions/upload-artifact@v7.0.0
       env:
         release: ${{ env.RELEASE }}
@@ -210,7 +210,7 @@ jobs:
         path: out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ env.ARCH }}_${{ matrix.bundle }}.zip
         retention-days: 31
     - name: Update Release ARM64EC
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+      if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
       uses: softprops/action-gh-release@v2.6.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-vs2022-x64.yml
+++ b/.github/workflows/build-vs2022-x64.yml
@@ -108,7 +108,7 @@ jobs:
 
           // List all artifacts for the repository
           const artifacts = await github.rest.actions.listArtifactsForRepo({
-              owner: 'openframeworks',
+              owner: context.repo.owner,
               repo: 'apothecary',
               sort: 'created_at',
               direction: 'desc',

--- a/.github/workflows/build-vs2022-x64.yml
+++ b/.github/workflows/build-vs2022-x64.yml
@@ -192,13 +192,13 @@ jobs:
       env:
         BUNDLE: ${{ matrix.bundle }}
     - name: Package
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
       working-directory: ${{ env.GITHUB_WORKSPACE }}
       run: scripts/package.sh
       env:
         BUNDLE: ${{ matrix.bundle }}
     - name: Upload binaries as Artifact
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' )
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' )
       uses: actions/upload-artifact@v7.0.0
       env:
         release: ${{ env.RELEASE }}
@@ -208,7 +208,7 @@ jobs:
         retention-days: 31
 
     - name: Update Release x64
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+      if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
       uses: softprops/action-gh-release@v2.6.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-vs2026-x64.yml
+++ b/.github/workflows/build-vs2026-x64.yml
@@ -108,7 +108,7 @@ jobs:
             if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir);
 
             const artifacts = await github.rest.actions.listArtifactsForRepo({
-              owner: 'openframeworks', repo: 'apothecary',
+              owner: context.repo.owner, repo: context.repo.repo,
               sort: 'created_at', direction: 'desc', per_page: 150
             });
 

--- a/.github/workflows/build-vs2026-x64.yml
+++ b/.github/workflows/build-vs2026-x64.yml
@@ -171,7 +171,7 @@ jobs:
 
       # ── Upload & Release (only on push to master/bleeding/tags) ─────────────
       - name: Upload binaries as Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: actions/upload-artifact@v7.0.0
         with:
           name: libs-${{ env.RELEASE }}-${{ env.TARGET }}-${{ env.VS_STUDIO }}-${{ matrix.arch }}-${{ matrix.bundle }}
@@ -179,7 +179,7 @@ jobs:
           retention-days: 31
 
       - name: Update GitHub Release
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: softprops/action-gh-release@v2.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-watchos.yml
+++ b/.github/workflows/build-watchos.yml
@@ -89,21 +89,21 @@ jobs:
           ARCH: SIM_arm64
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Package Binaries for Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: scripts/artifact/artifact.sh
         env:
           BUNDLE: ${{ matrix.bundle }}
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Upload binaries as Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: actions/upload-artifact@v7.0.0
         with:
           name: libs-watchos-${{ env.TARGET }}-${{ matrix.bundle }}
           path: out/openFrameworksLibs_${{ env.release }}_${{ env.TARGET }}_${{ matrix.bundle }}.tar.bz2
           retention-days: 30
       - name: Remove .tar.bz2 files
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         run: |
           echo "Removing .tar.bz2 files from out/ directory..."
           rm -f out/*.tar.bz2
@@ -118,14 +118,14 @@ jobs:
           BUNDLE: ${{ matrix.bundle }}
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
 #      - name: Package
-#        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+#        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
 #        working-directory: ${{ env.GITHUB_WORKSPACE }}
 #        run: scripts/package.sh
 #        env:
 #          BUNDLE: ${{ matrix.bundle }}
 #          GA_CI_SECRET: ${{ secrets.CI_SECRET }}
 #      - name: Update Release XCFramework
-#        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
+#        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))
 #        uses: johnwbyrd/update-release@v1.0.0
 #        with:
 #          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-xros.yml
+++ b/.github/workflows/build-xros.yml
@@ -90,21 +90,21 @@ jobs:
           ARCH: SIM_arm64
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Package Binaries for Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: scripts/artifact/artifact.sh
         env:
           BUNDLE: ${{ matrix.bundle }}
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Upload binaries as Artifact
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         uses: actions/upload-artifact@v7.0.0
         with:
           name: libs-xros-${{ env.TARGET }}-${{ matrix.bundle }}
           path: out/openFrameworksLibs_${{ env.release }}_${{ env.TARGET }}_${{ matrix.bundle }}.tar.bz2
           retention-days: 30
       - name: Remove .tar.bz2 files
-        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
         run: |
           echo "Removing .tar.bz2 files from out/ directory..."
           rm -f out/*.tar.bz2
@@ -118,14 +118,14 @@ jobs:
           BUNDLE: ${{ matrix.bundle }}
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
 #      - name: Package
-#        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+#        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
 #        working-directory: ${{ env.GITHUB_WORKSPACE }}
 #        run: scripts/package.sh
 #        env:
 #          BUNDLE: ${{ matrix.bundle }}
 #          GA_CI_SECRET: ${{ secrets.CI_SECRET }}
 #      - name: Update Release XCFramework
-#        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+#        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
 #        uses: johnwbyrd/update-release@v1.0.0
 #        with:
 #          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clean-up-artifacts.yml
+++ b/.github/workflows/clean-up-artifacts.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Log old artifacts for potential deletion
-      if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+      if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
       uses: actions/github-script@v8.0.0
       env:
         GH_TOKEN: ${{ secrets.CI_SECRET }}

--- a/apothecary/formulas/videoInput.sh
+++ b/apothecary/formulas/videoInput.sh
@@ -18,8 +18,6 @@ DEFINES=""
 GIT_URL=https://github.com/ofTheo/videoInput.git
 GIT_BRANCH=$VER
 
-CMAKE_LIST=https://raw.githubusercontent.com/danoli3/videoInput/master/videoInputSrcAndDemos/libs/videoInput/CMakeLists.txt
-
 # download the source code and unpack it into LIB_NAME
 function download() {
     echo "Running: git clone --branch ${GIT_BRANCH} ${GIT_URL}"

--- a/apothecary/formulas/videoInput.sh
+++ b/apothecary/formulas/videoInput.sh
@@ -24,15 +24,6 @@ CMAKE_LIST=https://raw.githubusercontent.com/danoli3/videoInput/master/videoInpu
 function download() {
     echo "Running: git clone --branch ${GIT_BRANCH} ${GIT_URL}"
     git clone --branch ${GIT_BRANCH} ${GIT_URL}
-
-}
-
-# prepare the build environment, executed inside the lib src dir
-function prepare() {
-    . "$DOWNLOADER_SCRIPT"
-    downloader ${CMAKE_LIST}
-
-    mv -f CMakeLists.txt "videoInputSrcAndDemos/libs/videoInput/CMakeLists.txt"
 }
 
 # executed inside the lib src dir
@@ -147,8 +138,10 @@ function copy() {
     else
         mkdir -p $1/lib/$TYPE
         mkdir -p $1/lib/$TYPE/$PLATFORM/
-        cp -v "videoInputSrcAndDemos/build_${TYPE}_${ARCH}/libvideoInput.a" $1/lib/$TYPE/$PLATFORM/videoInput.a
-
+        # cmake is passed -DLIBRARY_SUFFIX=${ARCH}, so the output may be named
+        # libvideoInput_${ARCH}.a rather than the plain libvideoInput.a.
+        LIB_A=$(ls "videoInputSrcAndDemos/build_${TYPE}_${ARCH}"/libvideoInput*.a 2>/dev/null | head -1)
+        cp -v "$LIB_A" $1/lib/$TYPE/$PLATFORM/videoInput.a
     fi
 
     echoWarning "TODO: License Copy"

--- a/apothecary/formulas/videoInput.sh
+++ b/apothecary/formulas/videoInput.sh
@@ -11,7 +11,7 @@ FORMULA_DEPENDS=()
 
 # define the version
 VER=master
-BUILD_ID=1
+BUILD_ID=2
 DEFINES=""
 
 # tools for git use


### PR DESCRIPTION
Fixed missing videoInput.a in certain environments  [apothecary/formulas/videoInput.sh](https://github.com/openframeworks/apothecary/compare/bleeding...ofrasp:apothecary:bleeding?expand=1#diff-46256cebbef1ad5ca9c0c182a0f253a9844e3d320c34f0ff90859eb5a458c3c4)

Also let's not block running tests on forks ... Other checks are still in place. When we fork we will need to manually activate this anyway. So no incidental builds.

Also tidied [`videoInput.sh`](https://github.com/openframeworks/apothecary/compare/bleeding...ofrasp:apothecary:bleeding?expand=1#diff-46256cebbef1ad5ca9c0c182a0f253a9844e3d320c34f0ff90859eb5a458c3c4) so CMakeLists does not come for a different repository.
