### PR TITLE
Fix msys2 builds for assimp, kiss, and tess2. Update pixman.sh, assimp.sh build-linux64.yml

### DIFF
--- a/.github/workflows/build-linux64.yml
+++ b/.github/workflows/build-linux64.yml
@@ -52,6 +52,7 @@ jobs:
       TARGET: ${{matrix.cfg.target}}
       GCC: ${{matrix.cfg.gcc}}
       ARCH: ${{matrix.cfg.arch}}
+      DISTRO: ubuntu
     steps:      
     - uses: actions/checkout@v6.0.2
     - name: Check if Workflow is disabled
@@ -117,12 +118,12 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         tag_name: ${{ env.RELEASE }}
         draft: false
-        files: out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ env.ARCH }}_${{ env.GCC }}.tar.bz2
+        files: out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ env.DISTRO }}_${{ env.ARCH }}_${{ env.GCC }}.tar.bz2
 
     - name: Clean
       if: github.event_name == 'push'
       run: |
-        rm -f out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ env.ARCH }}_${{ env.GCC }}.tar.bz2
+        rm -f out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ env.DISTRO }}_${{ env.ARCH }}_${{ env.GCC }}.tar.bz2
 
     - name: Package Split
       if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding' || contains(github.ref, 'refs/tags/'))

--- a/.github/workflows/build-msys2.yml
+++ b/.github/workflows/build-msys2.yml
@@ -31,9 +31,9 @@ jobs:
       run: |
         if [ "${{ env.DISABLE_WORKFLOW }}" == "true" ]; then
           echo "disabled=true" >> $GITHUB_ENV
-          echo "::set-output name=disabled::true"
+          echo "disabled=true" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=disabled::false"
+          echo "disabled=false" >> $GITHUB_OUTPUT
         fi
   build-msys2:
     if: needs.pre-check.outputs.workflow_disabled != 'true'
@@ -124,4 +124,3 @@ jobs:
           tag_name: ${{ env.RELEASE }}
           draft: false
           files: out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ matrix.flavor }}.zip
-

--- a/apothecary/formulas/assimp.sh
+++ b/apothecary/formulas/assimp.sh
@@ -6,7 +6,7 @@
 #
 # uses CMake
 
-FORMULA_TYPES=("osx" "ios" "watchos" "catos" "xros" "tvos" "android" "emscripten" "vs")
+FORMULA_TYPES=("osx" "ios" "watchos" "catos" "xros" "tvos" "android" "emscripten" "vs" "msys2" "linux")
 FORMULA_DEPENDS=("zlib")
 
 # define the version
@@ -225,7 +225,7 @@ function build() {
     elif [ "$TYPE" == "msys2" ]; then
         ZLIB_ROOT="$LIBS_ROOT/zlib/"
         ZLIB_INCLUDE_DIR="$LIBS_ROOT/zlib/include"
-        ZLIB_LIBRARY="$LIBS_ROOT/zlib/lib/$TYPE/$ARCH/zlib.a"
+        ZLIB_LIBRARY="$LIBS_ROOT/zlib/lib/$TYPE/$PLATFORM/zlib.a"
 
         DEFINES="
             -DCMAKE_C_STANDARD=${C_STANDARD} \
@@ -454,10 +454,26 @@ function copy() {
             secure "$1/lib/$TYPE/$PLATFORM/libassimp.lib" "assimp.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
         fi
     elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos|linux|msys2)$ ]]; then
-        cp -v -r build_${TYPE}_${PLATFORM}/include/* $1/include
+        cp -v -r build_${TYPE}_${ARCH}/include/* $1/include
         mkdir -p $1/lib/$TYPE/$PLATFORM/
-        cp -Rv build_${TYPE}_${PLATFORM}/lib/libassimp.a $1/lib/$TYPE/$PLATFORM/assimp.a
-        secure "$1/lib/$TYPE/$PLATFORM/libassimp.a" "assimp.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
+        cp -Rv build_${TYPE}_${ARCH}/lib/libassimp.a $1/lib/$TYPE/$PLATFORM/assimp.a
+        secure "$1/lib/$TYPE/$PLATFORM/assimp.a" "assimp.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
+        if [ "$TYPE" == "msys2" ]; then
+            mkdir -p $1/lib/$TYPE/$PLATFORM/pkgconfig
+            cat > $1/lib/$TYPE/$PLATFORM/pkgconfig/assimp.pc <<EOF
+prefix=$1
+exec_prefix=\${prefix}
+libdir=\${prefix}/lib/${TYPE}/${PLATFORM}
+includedir=\${prefix}/include
+
+Name: assimp
+Description: Open Asset Import Library
+Version: ${VER}
+Libs: \${libdir}/assimp.a
+Cflags: -I\${includedir}
+EOF
+            cp -v $1/lib/$TYPE/$PLATFORM/pkgconfig/assimp.pc $1/lib/$TYPE/$PLATFORM/assimp.pc
+        fi
     elif [ "$TYPE" == "android" ]; then
         mkdir -p $1/lib/$TYPE/$ABI/
         cp -Rv build_${TYPE}_${ABI}/include/* $1/include

--- a/apothecary/formulas/assimp.sh
+++ b/apothecary/formulas/assimp.sh
@@ -117,7 +117,7 @@ function build() {
             -DZLIB_LIBRARY=${ZLIB_LIBRARY} \
             -DCMAKE_VERBOSE_MAKEFILE=${VERBOSE_MAKEFILE}
 
-        cmake --build . --config Release -j${PARALLEL_MAKE}
+        cmake --build . --config Release -j${PARALLEL_MAKE} --target install
         cd ..
         rm -f CMakeCache.txt
 
@@ -453,14 +453,23 @@ function copy() {
             cp -v "build_${TYPE}_${PLATFORM}_release/lib/Release/assimp-vc${VC_VERSION}-mt.lib" $1/lib/$TYPE/$PLATFORM/Release/libassimp.lib
             secure "$1/lib/$TYPE/$PLATFORM/libassimp.lib" "assimp.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
         fi
-    elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos|linux|msys2)$ ]]; then
-        cp -v -r build_${TYPE}_${ARCH}/include/* $1/include
+    elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos)$ ]]; then
+        mkdir -p $1/lib/$TYPE/$PLATFORM/
+        cp -Rv build_${TYPE}_${PLATFORM}/Release/include/* $1/include/
+        cp -v build_${TYPE}_${PLATFORM}/Release/lib/libassimp.a $1/lib/$TYPE/$PLATFORM/assimp.a
+        secure "$1/lib/$TYPE/$PLATFORM/assimp.a" "assimp.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
+    elif [ "$TYPE" == "linux" ]; then
+        mkdir -p $1/lib/$TYPE/$PLATFORM/
+        cp -Rv build_${TYPE}_${PLATFORM}/Release/include/* $1/include/
+        cp -v build_${TYPE}_${PLATFORM}/Release/lib/libassimp.a $1/lib/$TYPE/$PLATFORM/assimp.a
+        secure "$1/lib/$TYPE/$PLATFORM/assimp.a" "assimp.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
+    elif [ "$TYPE" == "msys2" ]; then
+        cp -v -r build_${TYPE}_${ARCH}/include/* $1/include/
         mkdir -p $1/lib/$TYPE/$PLATFORM/
         cp -Rv build_${TYPE}_${ARCH}/lib/libassimp.a $1/lib/$TYPE/$PLATFORM/assimp.a
         secure "$1/lib/$TYPE/$PLATFORM/assimp.a" "assimp.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
-        if [ "$TYPE" == "msys2" ]; then
-            mkdir -p $1/lib/$TYPE/$PLATFORM/pkgconfig
-            cat > $1/lib/$TYPE/$PLATFORM/pkgconfig/assimp.pc <<EOF
+        mkdir -p $1/lib/$TYPE/$PLATFORM/pkgconfig
+        cat > $1/lib/$TYPE/$PLATFORM/pkgconfig/assimp.pc <<EOF
 prefix=$1
 exec_prefix=\${prefix}
 libdir=\${prefix}/lib/${TYPE}/${PLATFORM}
@@ -472,8 +481,7 @@ Version: ${VER}
 Libs: \${libdir}/assimp.a
 Cflags: -I\${includedir}
 EOF
-            cp -v $1/lib/$TYPE/$PLATFORM/pkgconfig/assimp.pc $1/lib/$TYPE/$PLATFORM/assimp.pc
-        fi
+        cp -v $1/lib/$TYPE/$PLATFORM/pkgconfig/assimp.pc $1/lib/$TYPE/$PLATFORM/assimp.pc
     elif [ "$TYPE" == "android" ]; then
         mkdir -p $1/lib/$TYPE/$ABI/
         cp -Rv build_${TYPE}_${ABI}/include/* $1/include

--- a/apothecary/formulas/kiss/kiss.sh
+++ b/apothecary/formulas/kiss/kiss.sh
@@ -5,7 +5,7 @@
 # http://sourceforge.net/projects/kissfft/
 
 FORMULA_TYPES=("linux" "msys2")
-FORMULA_DEPENDS=("libpng")
+FORMULA_DEPENDS=()
 
 # define the version
 VER=131.1.0
@@ -169,10 +169,11 @@ function copy() {
         secure "$1/lib/$TYPE/$PLATFORM/libkiss.a" "kiss.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
         cp -R "build_${TYPE}_${PLATFORM}/Release/include/" $1/include
     elif [ "$TYPE" == "msys2" ]; then
-        mkdir -p $1/lib/$TYPE/$PLATFORM
-        cp -v "build_${TYPE}_${PLATFORM}/Release/lib/libkissfft-float.a" $1/lib/$TYPE/$PLATFORM/libkiss.a
-        secure "$1/lib/$TYPE/$PLATFORM/libkiss.a" "kiss.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
+        mkdir -p $1/lib/$TYPE
+        cp -v "build_${TYPE}_${PLATFORM}/Release/lib/libkissfft-float.a" $1/lib/$TYPE/libkiss.a
+        secure "$1/lib/$TYPE/libkiss.a" "kiss.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
         cp -R "build_${TYPE}_${PLATFORM}/Release/include/" $1/include
+        echo "libkiss.a" > $1/lib/$TYPE/libsorder.make
     else
         cp -v lib/$TYPE/libkiss.a $1/lib/$TYPE/libkiss.a
     fi

--- a/apothecary/formulas/pixman/pixman.sh
+++ b/apothecary/formulas/pixman/pixman.sh
@@ -7,32 +7,42 @@ FORMULA_TYPES=("osx" "vs")
 FORMULA_DEPENDS=()
 
 # define the version
-VER=0.43.4
-SHA1=d7baa6377b6f48e29db011c669788bb1268d08ad
-BUILD_ID=1
+VER=0.46.4
+BUILD_ID=3
 DEFINES=""
 
 # tools for git use
 GIT_URL=http://anongit.freedesktop.org/git/pixman.git
 GIT_TAG=pixman-$VER
+# https://cairographics.org/releases/ (may block CI with Anubis)
 URL=https://cairographics.org/releases
+GIT_LAB=https://gitlab.freedesktop.org/pixman/pixman/-/archive/pixman-${VER}/pixman-pixman-${VER}
+
+# pixman 0.46+ release tarballs ship .gitlab-ci.d/meson-cross symlinks; Windows tar cannot create them.
+pixman_tar_extract() {
+    tar --exclude='.gitlab-ci.d' "$@"
+}
 
 # download the source code and unpack it into LIB_NAME
 function download() {
 
     . "$DOWNLOADER_SCRIPT"
 
-    downloader ${URL}/pixman-$VER.tar.gz
-    tar -xzf pixman-$VER.tar.gz
-    mv "pixman-$VER" pixman
-    CHECKSHA=$(shasum -a 1 pixman-$VER.tar.gz | cut -d ' ' -f1)
-    # if [ "$CHECKSHA" != "$SHA1" ] ; then
-    # 	echoError "ERROR! SHA did not Verify: [$CHECKSHA] SHA on Record:[$SHA1] - Developer has not updated SHA or Man in the Middle Attack"
-    # 	exit
-    # else
-    #     echo "SHA for Download Verified Successfully: [$CHECKSHA] SHA on Record:[$SHA1]"
-    # fi
-    rm pixman-$VER.tar.gz
+    local OFFICIAL="pixman-${VER}.tar.gz"
+    if downloader "${URL}/${OFFICIAL}" && gzip -t "${OFFICIAL}" 2>/dev/null; then
+        pixman_tar_extract -xzf "${OFFICIAL}"
+        rm "${OFFICIAL}"
+        mv "pixman-${VER}" pixman
+        return
+    fi
+    rm -f "${OFFICIAL}"
+
+    echo "cairographics.org download unavailable; using GitLab pixman/pixman archive"
+    local TARBALL="pixman-pixman-${VER}.tar"
+    downloader "${GIT_LAB}.tar"
+    pixman_tar_extract -xf "${TARBALL}"
+    rm "${TARBALL}"
+    mv "pixman-pixman-${VER}" pixman
 
 }
 

--- a/apothecary/formulas/tess2/tess2.sh
+++ b/apothecary/formulas/tess2/tess2.sh
@@ -264,10 +264,11 @@ function copy() {
         cp -v "build_${TYPE}_${PLATFORM}/libtess2.a" $1/lib/$TYPE/$PLATFORM/libtess2.a
         secure "$1/lib/$TYPE/$PLATFORM/libtess2.a" "tess2.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
     elif [ "$TYPE" == "msys2" ]; then
-        mkdir -p $1/lib/$TYPE/$PLATFORM/
+        mkdir -p $1/lib/$TYPE/
         cp -Rv "build_${TYPE}_${PLATFORM}/Release/include/" $1/
-        cp -v "build_${TYPE}_${PLATFORM}/libtess2.a" $1/lib/$TYPE/$PLATFORM/libtess2.a
-        secure "$1/lib/$TYPE/$PLATFORM/libtess2.a" "tess2.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
+        cp -v "build_${TYPE}_${PLATFORM}/libtess2.a" $1/lib/$TYPE/libtess2.a
+        secure "$1/lib/$TYPE/libtess2.a" "tess2.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
+        echo "libtess2.a" > $1/lib/$TYPE/libsorder.make
     elif [ "$TYPE" == "android" ]; then
         rm -rf $1/lib/$TYPE/$ABI
         mkdir -p $1/lib/$TYPE/$PLATFORM

--- a/scripts/calculate_formulas.sh
+++ b/scripts/calculate_formulas.sh
@@ -172,7 +172,7 @@ elif [[ "$TARGET" =~ ^(osx|macos|ios|tvos|xros|catos|watchos)$ ]]; then
             "poco"
         )
     fi
-elif [ "$TARGET" == "vs" ]; then
+elif [[ "$TARGET" =~ ^(vs|msys2)$ ]]; then
     FORMULAS=()
     if [ "$TBUNDLE" == "1" ] || [ "$TBUNDLE" == "0" ]; then
         FORMULAS=(


### PR DESCRIPTION
I know why would you use msys2 right?

1. Skip meson-cross symlink tree (not used to build pixman)
Extract with:

    `tar --exclude='.gitlab-ci.d'`

2. Ubuntu was missing
build-linux-cross.yml already includes DISTRO;
build-linux64.yml did not.
Updated build-linux64.yml so the release step sets DISTRO: ubuntu.

3. Use gitlab for Cairo fallback. Cairo in apothecary was already using GitLab (gitlab.freedesktop.org/cairo/cairo), not cairographics.org. cairographics.org is now using Anubis (anti-scraping middleware) GitHub Actions runners look like bots, so curl/wget can fail.

4. Fix assimp macOS copy to use PLATFORM build dir and Release install output Apple builds use build_${TYPE}_${PLATFORM} (e.g. build_osx_MAC), but copy() looked under build_${TYPE}_${ARCH} (e.g. build_osx_x86_64), so CI failed
