### PR TITLE
fix(tess2): test Apple TARGET_OS_* macros by value, not defined()

### DIFF
--- a/apothecary/formulas/tess2/tess2.patch
+++ b/apothecary/formulas/tess2/tess2.patch
@@ -18,7 +18,7 @@ index c27541e..eafb0aa 100755
 
  typedef float TESSreal;
 -typedef int TESSindex;
-+#if defined(TARGET_OS_IPHONE) || defined(TARGET_OS_IOS) || defined(ANDROID) || defined(TARGET_ANDROID) || defined(__EMSCRIPTEN__) || defined(TARGET_EMSCRIPTEN) || defined(TARGET_OS_WATCHOS) || defined(TARGET_OS_XROS) || defined(TARGET_OS_VISION) || defined(TARGET_CATOS) || defined(__QNX__) || ((defined(__ARMEL__) || defined(__arm__) || defined(__aarch32__)) && !defined(__APPLE__))
++#if (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE) || (defined(TARGET_OS_IOS) && TARGET_OS_IOS) || defined(ANDROID) || defined(TARGET_ANDROID) || defined(__EMSCRIPTEN__) || defined(TARGET_EMSCRIPTEN) || (defined(TARGET_OS_WATCHOS) && TARGET_OS_WATCHOS) || (defined(TARGET_OS_XROS) && TARGET_OS_XROS) || (defined(TARGET_OS_VISION) && TARGET_OS_VISION) || (defined(TARGET_CATOS) && TARGET_CATOS) || defined(__QNX__) || ((defined(__ARMEL__) || defined(__arm__) || defined(__aarch32__)) && !defined(__APPLE__))
 +	typedef unsigned short TESSindex;
 +#else
 +	typedef unsigned int TESSindex;


### PR DESCRIPTION
## Problem

Since #552, every macOS build gets **16-bit** `TESSindex` — and with it a 16-bit `ofIndexType` in openFrameworks (`ofConstants.h: typedef TESSindex ofIndexType`). Downstream, the OF renderers hardcode `GL_UNSIGNED_INT` for indexed draws on desktop, so every indexed/instanced draw reads 2× past the uploaded index buffer: out-of-range vertex fetches that render as garbage triangles or nothing at all, varying with GPU heap layout — non-deterministic across launches and relinks. It also caps indexed meshes at 65k vertices on macOS. Diagnosed on macOS 26 / Apple silicon against of_v20260730 nightlies; of_v20251123 (predating #552's artifacts) is unaffected.

## Cause

`TargetConditionals.h` defines **every** `TARGET_OS_*` macro on **every** Apple platform — as 1 or 0. On macOS, `TARGET_OS_IPHONE` is defined as 0, so `defined(TARGET_OS_IPHONE)` is true. And this very patch adds `#include <TargetConditionals.h>` to the top of `tesselator.h`, so the macros are always in scope.

History:

- #552 (`064906de`, "Tess2 fixes for emscripten") rewrote the index-width condition from its original value-form — `#if TARGET_OS_IPHONE || ANDROID || __ARMEL__ || EMSCRIPTEN` — to a `defined()`-form. The value-form was correct: undefined identifiers evaluate to 0 in `#if`, and Apple documents `TARGET_OS_*` macros as value-tested. The rewrite flipped macOS to 16-bit indices.
- #558 (`9a6d0b83`, "tess2 apple silicon fix arm defines") noticed Apple builds landing in the 16-bit branch, but attributed it to the `__arm__`-family defines and guarded those with `!defined(__APPLE__)`. `__arm__` / `__aarch32__` aren't defined on Apple arm64, so the actual macOS trigger — `defined(TARGET_OS_IPHONE)` — survived that fix.

## Fix

Test the Apple `TARGET_OS_*` macros by value in the canonical `defined(X) && X` form (robust under `-Wundef`), keeping plain `defined()` for the non-Apple macros and #558's arm guard intact.

A companion openFrameworks PR makes the renderers derive the GL index type from `sizeof(ofIndexType)` so they stay correct under either header: openframeworks/openFrameworks#8526. Both fixes stand alone.

## Verification

Applied both the current and the patched `tess2.patch` to a fresh libtess2 v1.0.2 checkout with the formula's own command (`patch -p1 -u -N`; both apply with zero rejects), then compiled `_Static_assert(sizeof(TESSindex) == EXPECT)` probes against the resulting headers, all with `-Wundef -Werror`:

| tess2.patch | Target | `sizeof(TESSindex)` |
|---|---|---|
| current (bleeding) | macOS | 2 — the bug |
| this PR | macOS | **4** — fixed |
| this PR | iOS (`xcrun --sdk iphoneos`, arm64) | 2 — unchanged |
| this PR | no Apple macros defined (Linux/Windows-like) | 4 — unchanged |

`-Wundef -Werror` staying silent confirms the `defined(X) && X` idiom is warning-clean on every target.
