### PR TITLE
GitHub Actions for Release and Auto tag latest in history to latest

### DIFF
--- a/.github/workflows/move-latest-tags.yml
+++ b/.github/workflows/move-latest-tags.yml
@@ -1,0 +1,84 @@
+# Move both latest floating tags to the bleeding branch tip after every push.
+# A merged PR produces a push event, so HEAD is the exact post-merge commit.
+#
+# Does not build or upload assets — build-* workflows still publish releases via
+# softprops/action-gh-release. This only force-moves lightweight tags so
+# consumers (git clone @ tag, LIB_TAG=latest, etc.) resolve the newest commit.
+#
+# Never force-moves version tags (v12.x.y).
+
+name: move-latest-tags
+
+on:
+  push:
+    branches:
+      - bleeding
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch whose tip receives the floating tags"
+        required: true
+        default: bleeding
+        type: choice
+        options:
+          - bleeding
+
+concurrency:
+  group: move-latest-tags-${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  retag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve branch
+        id: meta
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            BRANCH="${{ inputs.branch }}"
+          else
+            BRANCH="${{ github.ref_name }}"
+          fi
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "branch=${BRANCH}"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.meta.outputs.branch }}
+          # Prefer PAT if set (orgs that block GITHUB_TOKEN tag force-push)
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Force-move floating tags to branch tip
+        env:
+          BRANCH: ${{ steps.meta.outputs.branch }}
+        run: |
+          set -euo pipefail
+
+          SHA="$(git rev-parse HEAD)"
+          echo "branch=${BRANCH}"
+          echo "sha=${SHA}"
+
+          if [[ "${BRANCH}" != "bleeding" ]]; then
+            echo "Refusing to move latest tags from '${BRANCH}'" >&2
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -f latest "$SHA"
+          git tag -f latest-modular "$SHA"
+
+          # Push both refs together so they always identify the same commit.
+          git push origin \
+            refs/tags/latest \
+            refs/tags/latest-modular \
+            --force --atomic
+
+          echo "moved latest and latest-modular → ${SHA}"

--- a/.github/workflows/release-openframeworks.yml
+++ b/.github/workflows/release-openframeworks.yml
@@ -1,0 +1,115 @@
+name: Build and release openFrameworks libraries
+
+on:
+  workflow_dispatch:
+    inputs:
+      openframeworks_version:
+        description: "openFrameworks version to release (for example 12.2.0)"
+        required: true
+        type: string
+      overwrite_existing:
+        description: "Move an existing version tag to latest and rebuild its release"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: openframeworks-release-${{ inputs.openframeworks_version }}
+  cancel-in-progress: false
+
+jobs:
+  create-release-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the latest build
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          ref: latest
+          # A PAT is required: pushes made with GITHUB_TOKEN do not start the
+          # existing build-* workflows that upload the platform release assets.
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Validate and resolve version
+        id: release
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.openframeworks_version }}
+        run: |
+          set -euo pipefail
+
+          version="${INPUT_VERSION#v}"
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "Version must look like 12.2.0 (an optional leading v and prerelease suffix are accepted)." >&2
+            exit 1
+          fi
+
+          tag="v${version}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Check existing release tag
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          OVERWRITE_EXISTING: ${{ inputs.overwrite_existing }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            if [[ "${OVERWRITE_EXISTING}" != "true" ]]; then
+              echo "Tag ${RELEASE_TAG} already exists. Enable 'overwrite existing' to move and rebuild it." >&2
+              exit 1
+            fi
+            echo "Tag ${RELEASE_TAG} exists and will be moved to $(git rev-parse HEAD)."
+          fi
+
+      - name: Create and push release tag
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -f -a "$RELEASE_TAG" -m "openFrameworks ${RELEASE_VERSION} libraries"
+          if [[ "${{ inputs.overwrite_existing }}" == "true" ]]; then
+            git push origin "refs/tags/${RELEASE_TAG}" --force
+          else
+            git push origin "refs/tags/${RELEASE_TAG}"
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          SOURCE_SHA: ${{ steps.release.outputs.sha }}
+        run: |
+          set -euo pipefail
+          title="openFrameworks ${RELEASE_VERSION} libraries"
+          notes="Precompiled openFrameworks libraries built from the latest revision (${SOURCE_SHA}). Platform assets are added by the build workflows as they complete."
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release edit "$RELEASE_TAG" --title "$title" --notes "$notes"
+          else
+            gh release create "$RELEASE_TAG" \
+              --verify-tag \
+              --title "$title" \
+              --notes "$notes"
+          fi
+
+      - name: Summary
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          SOURCE_SHA: ${{ steps.release.outputs.sha }}
+        run: |
+          {
+            echo "## Release started"
+            echo
+            echo "Created \`${RELEASE_TAG}\` from \`latest\` at \`${SOURCE_SHA}\`."
+            echo "The tag push started the enabled platform build workflows; each successful build uploads its archive to this release."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@
 !/apothecary
 !/scripts
 !/docker
+!/.github
+!/.github/workflows
+/.github/workflows/*
+!/.github/workflows/move-latest-tags.yml
+!/.github/workflows/release-openframeworks.yml
 !/apothecary/**/*
 !/scripts/**/*
 /apothecary/build


### PR DESCRIPTION
  > Implemented input-triggered openFrameworks releases and automatic floating-
  > tag updates.
  >
  > - Added .github/workflows/release-openframeworks.yml, triggered manually
  >   through GitHub’s Run workflow button.
  >
  > - Accepts versions such as 12.2.0, v12.2.0, and 12.2.0-rc.1, normalized to
  >   tags such as v12.2.0.
  >
  > - Creates the version tag from the commit referenced by latest.
  > - Creates or updates the corresponding GitHub Release.
  > - Tag pushes trigger the existing enabled build-* workflows, which upload
  >   platform archives to the release.
  >
  > - Existing releases remain protected by default, with an explicit
  >   overwrite_existing option to move the tag and rebuild the release.
  >
  > - Uses PAT_TOKEN so tag pushes can trigger downstream workflows.
  > - Added move-latest-tags.yml, which moves both latest and latest-modular to
  >   the newest bleeding tip after every merge or push.
  >
  > - Both floating tags are pushed atomically so they always reference the same
  >   commit.
  >
  > - Updated .gitignore narrowly so both workflows can be committed.
  >
  > Validation passed: both workflow files parse successfully and git diff
  > --check is clean.