### PR TITLE
Update Release Tags / Emscripten 6.0.6

### DIFF
--- a/.github/workflows/build-emscripten.yml
+++ b/.github/workflows/build-emscripten.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   TARGET: "emscripten"
-  EMSDK_VERSION: "6.0.5"
+  EMSDK_VERSION: "6.0.6"
   USE_ARTIFACT: true
   PTHREADS_ENABLED: 1
   NO_FORCE: 1

--- a/.github/workflows/build-emscripten.yml
+++ b/.github/workflows/build-emscripten.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   TARGET: "emscripten"
-  EMSDK_VERSION: "5.0.7"
+  EMSDK_VERSION: "6.0.5"
   USE_ARTIFACT: true
   PTHREADS_ENABLED: 1
   NO_FORCE: 1
@@ -241,4 +241,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: "latest-modular"
           files: out/*.tar.bz2
-

--- a/.github/workflows/move-latest-tags.yml
+++ b/.github/workflows/move-latest-tags.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Force-move floating tags to branch tip
         env:
           BRANCH: ${{ steps.meta.outputs.branch }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -80,5 +81,17 @@ jobs:
             refs/tags/latest \
             refs/tags/latest-modular \
             --force --atomic
+
+          # Moving a git tag does not refresh the existing GitHub Release
+          # record. Retarget it explicitly so the Releases page shows this SHA
+          # and receives a new updated_at timestamp.
+          for release_tag in latest latest-modular; do
+            if gh release view "$release_tag" >/dev/null 2>&1; then
+              gh release edit "$release_tag" --target "$SHA" --verify-tag
+              echo "retargeted release ${release_tag} → ${SHA}"
+            else
+              echo "No GitHub Release exists for ${release_tag}; tag was still moved."
+            fi
+          done
 
           echo "moved latest and latest-modular → ${SHA}"

--- a/scripts/emscripten/setup.sh
+++ b/scripts/emscripten/setup.sh
@@ -2,7 +2,7 @@
 
 # Default EMSDK path and version
 EMSDK=${EMSDK:-$HOME/emsdk}
-EMSDK_VERSION=${EMSDK_VERSION:-latest}  # Default to 'latest' if unset
+EMSDK_VERSION=${EMSDK_VERSION:-6.0.5}
 SETUP_STATUS_FILE="$HOME/.emsdk_setup_status"
 
 check_emsdk() {

--- a/scripts/emscripten/setup.sh
+++ b/scripts/emscripten/setup.sh
@@ -2,7 +2,7 @@
 
 # Default EMSDK path and version
 EMSDK=${EMSDK:-$HOME/emsdk}
-EMSDK_VERSION=${EMSDK_VERSION:-6.0.5}
+EMSDK_VERSION=${EMSDK_VERSION:-6.0.6}
 SETUP_STATUS_FILE="$HOME/.emsdk_setup_status"
 
 check_emsdk() {

--- a/scripts/emscripten/setup_env_unix.sh
+++ b/scripts/emscripten/setup_env_unix.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="6.0.5"
+VERSION="6.0.6"
 
 # Check if EMSDK is set and valid
 if [[ -z "$EMSDK" || ! -d "$EMSDK/upstream/emscripten" ]]; then

--- a/scripts/emscripten/setup_env_unix.sh
+++ b/scripts/emscripten/setup_env_unix.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-VERSION="latest"
+VERSION="6.0.5"
 
 # Check if EMSDK is set and valid
 if [[ -z "$EMSDK" || ! -d "$EMSDK/upstream/emscripten" ]]; then
-    echo "🔹 Emscripten SDK not found or invalid. Installing the latest version..."
+    echo "🔹 Emscripten SDK not found or invalid. Installing version $VERSION..."
     cd $HOME
     if [ ! -d "emsdk" ]; then
         git clone https://github.com/emscripten-core/emsdk.git
@@ -23,7 +23,7 @@ if [[ -z "$EMSDK" || ! -d "$EMSDK/upstream/emscripten" ]]; then
     echo 'export PATH="$HOME/emsdk:$HOME/emsdk/upstream/emscripten:$PATH"' >> $HOME/.bashrc
     source $HOME/.bashrc
 else
-    echo "Emscripten SDK found at $EMSDK. Updating to the latest version..."
+    echo "Emscripten SDK found at $EMSDK. Updating to version $VERSION..."
     cd "$EMSDK"
     ./emsdk install "$VERSION"
     ./emsdk activate "$VERSION" --permanent


### PR DESCRIPTION
Fixed the workflow to update both layers:

  - Git tags latest and latest-modular are atomically moved to the bleeding tip.
  - Existing GitHub Release records are explicitly retargeted to that exact SHA
    using gh release edit --target.

  Releases page reflects the update to content now

Emscripten to 6.0.6

