### PR TITLE
Optimize Visual Studio CI caching and update release action

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -203,7 +203,7 @@ jobs:
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Update Release emscripten
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.RELEASE }}

--- a/.github/workflows/build-catos.yml
+++ b/.github/workflows/build-catos.yml
@@ -121,7 +121,7 @@ jobs:
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Update Release XCFramework
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.RELEASE }}

--- a/.github/workflows/build-emscripten.yml
+++ b/.github/workflows/build-emscripten.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Update Release
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.RELEASE }}
@@ -239,7 +239,7 @@ jobs:
 
       - name: Upload to GitHub Release
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: "latest-modular"

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -245,7 +245,7 @@ jobs:
 
       - name: Upload modular Poco to latest-modular
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') && matrix.bundle == 3
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: latest-modular
@@ -258,7 +258,7 @@ jobs:
           BUNDLE: ${{ matrix.bundle }}
       - name: Update Release XCFramework
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.RELEASE }}
@@ -446,21 +446,21 @@ jobs:
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Update Release macOS 1
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.RELEASE }}
           files: xout_1/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_1.tar.bz2
       - name: Update Release macOS 2
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.RELEASE }}
           files: xout_2/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_2.tar.bz2
       - name: Update Release macOS 3
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.RELEASE }}

--- a/.github/workflows/build-linux-cross.yml
+++ b/.github/workflows/build-linux-cross.yml
@@ -92,7 +92,7 @@ jobs:
       run: ls -lah out/
     - name: Update GitHub Release
       if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-      uses: softprops/action-gh-release@v3.0.2
+      uses: softprops/action-gh-release@v3.0.3
       with:
         token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
         tag_name: ${{ env.RELEASE }}

--- a/.github/workflows/build-linux-rpi.yml
+++ b/.github/workflows/build-linux-rpi.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Update Release
         if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.RELEASE }}

--- a/.github/workflows/build-linux64.yml
+++ b/.github/workflows/build-linux64.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Update Release
         if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.RELEASE }}
@@ -154,7 +154,7 @@ jobs:
 
       - name: Upload to GitHub Release
         if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') && env.GCC == 'gcc10'
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: "latest-modular"

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -224,7 +224,7 @@ jobs:
 
       - name: Upload to GitHub Release (latest-modular)
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding') && matrix.bundle == 3
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: "latest-modular"
@@ -261,7 +261,7 @@ jobs:
           retention-days: 7
       - name: Update Release XCFramework
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.RELEASE }}

--- a/.github/workflows/build-msys2.yml
+++ b/.github/workflows/build-msys2.yml
@@ -124,7 +124,7 @@ jobs:
         run: ls -lah out/
       - name: Update Release
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.RELEASE }}

--- a/.github/workflows/build-tvos.yml
+++ b/.github/workflows/build-tvos.yml
@@ -206,7 +206,7 @@ jobs:
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Update Release XCFramework
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.RELEASE }}

--- a/.github/workflows/build-vs2022-arm64.yml
+++ b/.github/workflows/build-vs2022-arm64.yml
@@ -1,6 +1,7 @@
 name: build-vs2022-arm64
 
 on:
+  workflow_dispatch:
   push:
     paths-ignore:
     - '**/*.md'
@@ -13,6 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: write
 
 env:
@@ -21,7 +23,7 @@ env:
   NO_FORCE: 1
   VS_VER: 17
   GA_CI_SECRET: ${{ secrets.CI_SECRET }}
-  USE_ARTIFACT: false
+  USE_ARTIFACT: true
   DISABLE_WORKFLOW: "false"
 
 jobs:  
@@ -80,6 +82,11 @@ jobs:
           mingw-w64-x86_64-ninja
     - name: Clone repository
       uses: actions/checkout@v7.0.1
+    - name: Restore Apothecary build cache
+      uses: actions/cache@v5
+      with:
+        path: apothecary/build
+        key: apothecary-vs${{ env.VS_VER }}-${{ env.ARCH }}-bundle-${{ matrix.bundle }}-${{ hashFiles('apothecary/formulas/**', 'apothecary/apothecary', 'scripts/build.sh', 'scripts/calculate_formulas.sh', 'scripts/vs/**') }}
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v3
     - name: Determine Release
@@ -100,6 +107,8 @@ jobs:
     - name: 'Download artifacts'
       uses: actions/github-script@v9.0.0
       if: env.USE_ARTIFACT == 'true'
+      env:
+        MATRIX_BUNDLE: ${{ matrix.bundle }}
       with:
         script: |
           const fs = require('fs');
@@ -130,7 +139,7 @@ jobs:
           const max = 1;
 
           for (const artifact of artifacts.data.artifacts) {
-            const isArtifactMatch = artifact.name.includes(`libs-${release}-${target}-${arch}`) && !artifact.expired;
+            const isArtifactMatch = artifact.name === artifactName && !artifact.expired;
             if (isArtifactMatch) {
               const download = await github.rest.actions.downloadArtifact({
                 owner: context.repo.owner,
@@ -213,10 +222,9 @@ jobs:
         retention-days: 31
     - name: Update Release ARM64
       if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-      uses: softprops/action-gh-release@v3.0.2
+      uses: softprops/action-gh-release@v3.0.3
       with:
         token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
         tag_name: ${{ env.RELEASE }}
         draft: false
         files: out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ env.ARCH }}_${{ matrix.bundle }}.zip
-

--- a/.github/workflows/build-vs2022-arm64ec.yml
+++ b/.github/workflows/build-vs2022-arm64ec.yml
@@ -1,6 +1,7 @@
 name: build-vs2022-arm64ec
 
 on:
+  workflow_dispatch:
   push:
     paths-ignore:
     - '**/*.md'
@@ -13,6 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: write
 
 env:
@@ -21,7 +23,7 @@ env:
   NO_FORCE: 1
   VS_VER: 17
   GA_CI_SECRET: ${{ secrets.CI_SECRET }}
-  USE_ARTIFACT: false
+  USE_ARTIFACT: true
   DISABLE_WORKFLOW: "false"
 
 jobs:
@@ -84,6 +86,11 @@ jobs:
           mingw-w64-x86_64-ninja
     - name: Clone repository
       uses: actions/checkout@v7.0.1
+    - name: Restore Apothecary build cache
+      uses: actions/cache@v5
+      with:
+        path: apothecary/build
+        key: apothecary-vs${{ env.VS_VER }}-${{ env.ARCH }}-bundle-${{ matrix.bundle }}-${{ hashFiles('apothecary/formulas/**', 'apothecary/apothecary', 'scripts/build.sh', 'scripts/calculate_formulas.sh', 'scripts/vs/**') }}
       
     - name: Determine Release
       id: vars
@@ -103,6 +110,8 @@ jobs:
     - name: 'Download artifacts'
       uses: actions/github-script@v9.0.0
       if: env.USE_ARTIFACT == 'true'
+      env:
+        MATRIX_BUNDLE: ${{ matrix.bundle }}
       with:
         script: |
           const fs = require('fs');
@@ -133,7 +142,7 @@ jobs:
           const max = 1;
 
           for (const artifact of artifacts.data.artifacts) {
-            const isArtifactMatch = artifact.name.includes(`libs-${release}-${target}-${arch}`) && !artifact.expired;
+            const isArtifactMatch = artifact.name === artifactName && !artifact.expired;
             if (isArtifactMatch) {
               const download = await github.rest.actions.downloadArtifact({
                 owner: context.repo.owner,
@@ -216,7 +225,7 @@ jobs:
         retention-days: 31
     - name: Update Release ARM64EC
       if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-      uses: softprops/action-gh-release@v3.0.2
+      uses: softprops/action-gh-release@v3.0.3
       with:
         token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
         tag_name: ${{ env.RELEASE }}

--- a/.github/workflows/build-vs2022-x64.yml
+++ b/.github/workflows/build-vs2022-x64.yml
@@ -1,6 +1,7 @@
 name: build-vs2022-64
 
 on:
+  workflow_dispatch:
   push:
     paths-ignore:
     - '**/*.md'
@@ -13,6 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: write
 
 env:
@@ -21,7 +23,7 @@ env:
   NO_FORCE: 1
   VS_VER: 17
   GA_CI_SECRET: ${{ secrets.CI_SECRET }}
-  USE_ARTIFACT: false
+  USE_ARTIFACT: true
   DISABLE_WORKFLOW: "false"
 
 jobs:  
@@ -80,6 +82,11 @@ jobs:
           mingw-w64-x86_64-ninja
     - name: Clone repository
       uses: actions/checkout@v7.0.1
+    - name: Restore Apothecary build cache
+      uses: actions/cache@v5
+      with:
+        path: apothecary/build
+        key: apothecary-vs${{ env.VS_VER }}-${{ env.ARCH }}-bundle-${{ matrix.bundle }}-${{ hashFiles('apothecary/formulas/**', 'apothecary/apothecary', 'scripts/build.sh', 'scripts/calculate_formulas.sh', 'scripts/vs/**') }}
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v3
     - name: Determine Release
@@ -100,6 +107,8 @@ jobs:
     - name: 'Download artifacts'
       uses: actions/github-script@v9.0.0
       if: env.USE_ARTIFACT == 'true'
+      env:
+        MATRIX_BUNDLE: ${{ matrix.bundle }}
       with:
         script: |
           const fs = require('fs');
@@ -130,7 +139,7 @@ jobs:
           const max = 1;
 
           for (const artifact of artifacts.data.artifacts) {
-            const isArtifactMatch = artifact.name.includes(`libs-${release}-${target}-${arch}`) && !artifact.expired;
+            const isArtifactMatch = artifact.name === artifactName && !artifact.expired;
             if (isArtifactMatch) {
               const download = await github.rest.actions.downloadArtifact({
                 owner: context.repo.owner,
@@ -214,7 +223,7 @@ jobs:
 
     - name: Update Release x64
       if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-      uses: softprops/action-gh-release@v3.0.2
+      uses: softprops/action-gh-release@v3.0.3
       with:
         token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
         tag_name: ${{ env.RELEASE }}

--- a/.github/workflows/build-vs2026-x64.yml
+++ b/.github/workflows/build-vs2026-x64.yml
@@ -1,6 +1,7 @@
 name: build-vs2026
 
 on:
+  workflow_dispatch:
   push:
     paths-ignore:
       - '**/*.md'
@@ -13,6 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: write
 
 env:
@@ -21,7 +23,7 @@ env:
   VS_VER: 18
   NO_FORCE: 1
   GA_CI_SECRET: ${{ secrets.CI_SECRET }}
-  USE_ARTIFACT: false
+  USE_ARTIFACT: true
   DISABLE_WORKFLOW: "false"
 
 jobs:
@@ -80,6 +82,12 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v7.0.1
 
+      - name: Restore Apothecary build cache
+        uses: actions/cache@v5
+        with:
+          path: apothecary/build
+          key: apothecary-vs${{ env.VS_VER }}-${{ matrix.arch }}-bundle-${{ matrix.bundle }}-${{ hashFiles('apothecary/formulas/**', 'apothecary/apothecary', 'scripts/build.sh', 'scripts/calculate_formulas.sh', 'scripts/vs/**') }}
+
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v3
 
@@ -104,6 +112,8 @@ jobs:
       - name: 'Download artifacts'
         uses: actions/github-script@v9.0.0
         if: env.USE_ARTIFACT == 'true'
+        env:
+          MATRIX_BUNDLE: ${{ matrix.bundle }}
         with:
           script: |
             const fs = require('fs');
@@ -119,12 +129,14 @@ jobs:
             const target = process.env.TARGET;
             const studio = process.env.VS_STUDIO;
             const arch = process.env.ARCH;
+            const bundle = process.env.MATRIX_BUNDLE;
             const release = process.env.RELEASE;
+            const artifactName = `libs-${release}-${target}-${studio}-${arch}-${bundle}`;
 
             let count = 0;
             const max = 1;
             for (const artifact of artifacts.data.artifacts) {
-              const isArtifactMatch = artifact.name.includes(`libs-${release}-${target}-${studio}-${arch}`) && !artifact.expired;
+              const isArtifactMatch = artifact.name === artifactName && !artifact.expired;
               if (isArtifactMatch) {
                 const download = await github.rest.actions.downloadArtifact({
                   owner: context.repo.owner, repo: context.repo.repo,
@@ -184,7 +196,7 @@ jobs:
 
       - name: Update GitHub Release
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.RELEASE }}

--- a/.github/workflows/build-xros.yml
+++ b/.github/workflows/build-xros.yml
@@ -129,7 +129,7 @@ jobs:
           GA_CI_SECRET: ${{ secrets.CI_SECRET }}
       - name: Update Release XCFramework
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
-        uses: softprops/action-gh-release@v3.0.2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.RELEASE }}


### PR DESCRIPTION
## Summary
- enable prior artifact restoration for all VS2022 and VS2026 build matrices
- require exact release/toolchain/architecture/bundle artifact matches
- cache matrix-specific Apothecary build trees with build-input-based invalidation
- add manual dispatch support to all Visual Studio workflows
- update all `softprops/action-gh-release` uses from v3.0.2 to v3.0.3

## Validation
- parsed all GitHub Actions workflow YAML files
- verified all 22 release-action references use v3.0.3
- ran `git diff --check`
- repository commit and pre-push hooks passed