### PR TITLE
Add complete Linux modular library builds

### DIFF
--- a/.github/workflows/build-linux-modular.yml
+++ b/.github/workflows/build-linux-modular.yml
@@ -1,0 +1,76 @@
+name: build-linux-modular
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [bleeding, master]
+    paths-ignore: ['**/*.md']
+  pull_request:
+    paths-ignore: ['**/*.md']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Linux modular - ${{ matrix.arch }} - GCC14
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: '64'
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    env:
+      TARGET: linux
+      TYPE: linux
+      ARCH: ${{ matrix.arch }}
+      GCC: gcc14
+      GCC_VERSION: '14'
+      CC: gcc-14
+      CXX: g++-14
+      NO_FORCE: 1
+      FORMULAS_OVERRIDE: pixman pkg-config zlib utf8 boost libpng brotli pugixml freetype libxml2 svgtiny FreeImage assimp glew glfw glm json libusb kiss portaudio rtAudio tess2 uriparser opencv cairo fmt openssl nghttp2 nghttp3 ngtcp2 libssh2 curl poco dawn
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            autoconf automake build-essential ccache cmake curl dos2unix flex \
+            g++-14 gcc-14 git gperf libasound2-dev libegl1-mesa-dev \
+            libfftw3-dev libfontconfig1-dev libgl1-mesa-dev libglu1-mesa-dev \
+            libjack-dev libpulse-dev libtool libudev-dev libwayland-dev \
+            libx11-dev libxcursor-dev libxext-dev libxi-dev libxinerama-dev \
+            libxkbcommon-dev libxrandr-dev meson ninja-build perl pkg-config \
+            python3 python3-pip unzip xorg-dev
+
+      - name: Restore modular build cache
+        uses: actions/cache@v5
+        with:
+          path: apothecary/build
+          key: linux-modular-gcc14-${{ matrix.arch }}-${{ hashFiles('apothecary/formulas/**', 'apothecary/apothecary', 'scripts/build.sh', 'scripts/calculate_formulas.sh') }}
+
+      - name: Build modular libraries
+        run: scripts/build.sh
+
+      - name: Package modular libraries
+        if: github.event_name == 'push'
+        env:
+          ALWAYS_BUILD: 1
+        run: scripts/package-individual.sh
+
+      - name: Upload modular libraries
+        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push'
+        uses: softprops/action-gh-release@v3.0.3
+        with:
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          tag_name: latest-modular
+          files: out/oF_*_linux_${{ matrix.arch }}_gcc14.tar.bz2

--- a/.github/workflows/build-linux-rpi.yml
+++ b/.github/workflows/build-linux-rpi.yml
@@ -24,8 +24,6 @@ env:
   CROSS_OS: bookworm
   NO_FORCE: 1
   USE_ARTIFACT: false
-  # Prove the QEMU sysroot + GCC 10 cross compiler before brewing the full core set.
-  FORMULAS_OVERRIDE: zlib
   GA_CI_SECRET: ${{ secrets.CI_SECRET }}
 
 jobs:
@@ -110,3 +108,19 @@ jobs:
             out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ env.ARCH }}_${{ env.GCC }}.tar.bz2
             out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ env.ARCH }}_${{ env.GCC }}.tar.bz2.sha256
             out/openFrameworksLibs_${{ env.RELEASE }}_${{ env.TARGET }}_${{ env.ARCH }}_${{ env.GCC }}.tar.bz2.manifest.json
+
+      - name: Clean canonical archive before modular packaging
+        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push'
+        run: rm -f out/openFrameworksLibs*.tar.bz2
+
+      - name: Package modular libraries
+        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        run: scripts/package-individual.sh
+
+      - name: Upload modular libraries
+        if: github.repository == 'openframeworks/apothecary' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        uses: softprops/action-gh-release@v3.0.3
+        with:
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          tag_name: latest-modular
+          files: out/oF_*_linux_${{ env.ARCH }}_gcc10.tar.bz2

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 !/.github/workflows/move-latest-tags.yml
 !/.github/workflows/release-openframeworks.yml
 !/.github/workflows/build-opencv-cuda-modular.yml
+!/.github/workflows/build-linux-modular.yml
 !/.github/workflows/test-openframeworks-libraries.yml
 !/.github/workflows/validate-formula-sources.yml
 !/apothecary/**/*

--- a/apothecary/formulas/assimp.sh
+++ b/apothecary/formulas/assimp.sh
@@ -394,7 +394,8 @@ function build() {
             -DBUILD_SHARED_LIBS=OFF
             -DASSIMP_BUILD_TESTS=0
             -DASSIMP_BUILD_SAMPLES=0
-            -DASSIMP_BUILD_3MF_IMPORTER=0"
+            -DASSIMP_BUILD_3MF_IMPORTER=0
+            -DASSIMP_WARNINGS_AS_ERRORS=OFF"
 
         if [ $CROSSCOMPILING -eq 1 ]; then
             source $APOTHECARY_DIR/configure/${TYPE}${PLATFORM}_configure.sh

--- a/apothecary/formulas/boost/boost.sh
+++ b/apothecary/formulas/boost/boost.sh
@@ -9,9 +9,9 @@ FORMULA_TYPES=()
 FORMULA_DEPENDS=()
 
 # define the version
-VERSION=1.66.0
-SHA256=71c32f4085e3adef4fffc90674a01079665d281d1de2aea6c6955db8567deae1
-UNCOMPRESSED_NAME=boost_1_66_0
+VERSION=1.87.0
+SHA256=f55c340aa49763b1925ccf02b2e83f35fdcf634c9d5164a2acb87540173c741d
+UNCOMPRESSED_NAME=boost_1_87_0
 TARBALL=$UNCOMPRESSED_NAME.tar.gz
 BUILD_ID=1
 DEFINES=""
@@ -23,13 +23,13 @@ EXTRA_CPPFLAGS="-std=c++${CPP_STANDARD} -stdlib=libc++ -fPIC -DBOOST_SP_USE_SPIN
 
 # tools for git use
 
-OFFICIAL_DOWNLOAD_HOST=https://boostorg.jfrog.io/artifactory/main
+OFFICIAL_DOWNLOAD_HOST=https://archives.boost.io
 
 # URL=${OFFICIAL_DOWNLOAD_HOST}/release/$VERSION/source/$UNCOMPRESSED_NAME.tar.gz
 
 WIN_URL=${OFFICIAL_DOWNLOAD_HOST}/release/$VERSION/source/$UNCOMPRESSED_NAME.zip
 
-URL=https://boostorg.jfrog.io/artifactory/main/release/1.66.0/source/$TARBALL
+URL=${OFFICIAL_DOWNLOAD_HOST}/release/${VERSION}/source/${TARBALL}
 
 # download the source code and unpack it into LIB_NAME
 function download() {
@@ -63,8 +63,8 @@ function prepare() {
         ./bootstrap.sh --with-toolset=clang --with-libraries=filesystem
     elif [ "$TYPE" == "emscripten" ]; then
         ./bootstrap.sh --with-libraries=filesystem
-    elif [ "$TYPE" == "emscripten" ]; then
-        ./bootstrap.sh --with-libraries=filesystem
+    elif [ "$TYPE" == "linux" ]; then
+        ./bootstrap.sh --with-toolset=gcc --with-libraries=filesystem
     elif [[ "${TYPE}" == "ios" || "${TYPE}" == "tvos" ]]; then
         mkdir -p lib/
         mkdir -p build/
@@ -96,6 +96,12 @@ function build() {
 
     elif [ "$TYPE" == "osx" ]; then
         ./b2 -j${PARALLEL_MAKE} toolset=clang cxxflags="-std=c++${CPP_STANDARD} -stdlib=libc++ -arch arm64 -arch x86_64 -Wno-implicit-function-declaration -mmacosx-version-min=${OSX_MIN_SDK_VER}" linkflags="-stdlib=libc++" threading=multi variant=release --build-dir=build --stage-dir=stage link=static stage
+        cd tools/bcp
+        ../../b2
+    elif [ "$TYPE" == "linux" ]; then
+        ./b2 -j${PARALLEL_MAKE} toolset=gcc cxxflags="-std=c++${CPP_STANDARD} -fPIC" \
+            threading=multi variant=release --build-dir=build --stage-dir=stage \
+            --with-filesystem link=static stage
         cd tools/bcp
         ../../b2
     elif [[ "$TYPE" == "ios" || "${TYPE}" == "tvos" ]]; then
@@ -342,6 +348,10 @@ function copy() {
         rsync -ar install_dir/boost/* $1/include/boost/
         cp stage/lib/libboost_filesystem.a $1/lib/$TYPE/boost_filesystem.a
         cp stage/lib/libboost_system.a $1/lib/$TYPE/boost_system.a
+    elif [ "$TYPE" == "linux" ]; then
+        dist/bin/bcp filesystem install_dir
+        rsync -ar install_dir/boost/* $1/include/boost/
+        cp stage/lib/libboost_filesystem.a $1/lib/$TYPE/boost_filesystem.a
     elif [[ "$TYPE" == "ios" || "$TYPE" == "tvos" ]]; then
         bcp filesystem install_dir
         OUTPUT_DIR_LIB=$(pwd)/lib/boost/ios/

--- a/apothecary/formulas/cairo/cairo.sh
+++ b/apothecary/formulas/cairo/cairo.sh
@@ -12,7 +12,7 @@
 # prefix (install location) and use a custom copy of pkg-config which returns
 # the dependent lib cflags/ldflags for that prefix (cairo/apothecary-build)
 
-FORMULA_TYPES=("osx" "vs")
+FORMULA_TYPES=("osx" "vs" "linux")
 FORMULA_DEPENDS=("zlib" "libpng" "pixman" "freetype")
 
 # tell apothecary we want to manually call the dependency commands
@@ -213,7 +213,7 @@ function build() {
             ${CMAKE_WIN_SDK}
         cmake --build . --config Release -j${PARALLEL_MAKE} --target install
         cd ..
-    elif [ "$TYPE" == "osx" ]; then
+    elif [ "$TYPE" == "osx" ] || [ "$TYPE" == "linux" ]; then
 
         LIBS_ROOT=$(realpath $LIBS_DIR)
 
@@ -272,20 +272,28 @@ function build() {
         	-DFREETYPE_LIBS=${FREETYPE_LIBRARY} \
         	-DBUILD_GTK_DOC=OFF -DNO_BUILD_TESTS=ON -DNO_DEPENDENCY_TRACKING=ON -DBUILD_XLIB=OFF -DNO_QT=ON -DBUILD_SHARED_LIBS=OFF -DNO_QUARTZ_FONT=OFF -DNO_QUARTZ=OFF -DNO_QUARTZ_IMAGE=OFF"
 
+        local PLATFORM_DEFS=()
+        if [ "$TYPE" == "osx" ]; then
+            PLATFORM_DEFS=(
+                -DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/ios.toolchain.cmake"
+                -DPLATFORM="$PLATFORM"
+                -DENABLE_BITCODE=OFF
+                -DENABLE_ARC=OFF
+                -DDEPLOYMENT_TARGET="$MIN_SDK_VER"
+            )
+        else
+            PLATFORM_DEFS=(-DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/linux${PLATFORM}.toolchain.cmake")
+        fi
         cmake .. ${DEFS} \
-            -DCMAKE_TOOLCHAIN_FILE=$APOTHECARY_DIR/toolchains/ios.toolchain.cmake \
-            -DPLATFORM=$PLATFORM \
+            "${PLATFORM_DEFS[@]}" \
             -DBROTLIDEC_INCLUDE_DIRS="${LIBBROTLI_INCLUDE_DIR}" \
             -DBROTLI_INCLUDE_DIR="${LIBBROTLI_INCLUDE_DIR}" \
             -DBROTLIDEC_LIBRARIES="${LIBBROTLI_LIBRARY};${LIBBROTLI_DEC_LIB};${LIBBROTLI_ENC_LIB}" \
             -DCMAKE_INCLUDE_PATH="${LIBBROTLI_INCLUDE_DIR};${FREETYPE_INCLUDE_DIR};${LIBPNG_INCLUDE_DIR};${ZLIB_INCLUDE_DIR};${PIXMAN_INCLUDE_DIR}" \
             -DCMAKE_LIBRARY_PATH="${LIBBROTLI_LIBRARY};${LIBBROTLI_DEC_LIB};${LIBBROTLI_ENC_LIB};${FREETYPE_LIBRARY};${LIBPNG_LIBRARY};${ZLIB_LIBRARY};${PIXMAN_LIBRARY}" \
-            -DENABLE_BITCODE=OFF \
-            -DENABLE_ARC=OFF \
             -DBUILD_SHARED_LIBS=OFF \
             -DBUILD_STATIC_LIBS=ON \
             -DENABLE_VISIBILITY=OFF \
-            -DDEPLOYMENT_TARGET=${MIN_SDK_VER} \
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
             -DCMAKE_MINIMUM_REQUIRED_VERSION=3.22 \
             -DNO_FONTCONFIG=OFF \
@@ -322,7 +330,7 @@ function copy() {
         cp -Rv "build_${TYPE}_${ARCH}/Release/include/"* $1/include/
         cp -v "build_${TYPE}_${ARCH}/Release/lib/cairo-static.lib" $1/lib/$TYPE/$PLATFORM/libcairo.lib
         secure "$1/lib/$TYPE/$PLATFORM/libcairo.lib" "cairo.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
-    elif [ "$TYPE" == "osx" ]; then
+    elif [ "$TYPE" == "osx" ] || [ "$TYPE" == "linux" ]; then
         mkdir -p $1/lib/$TYPE/$PLATFORM/
         cp -v "build_${TYPE}_${PLATFORM}/Release/lib/libcairo-static.a" $1/lib/$TYPE/$PLATFORM/libcairo.a
         secure "$1/lib/$TYPE/$PLATFORM/libcairo.a" "cairo.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
@@ -345,7 +353,7 @@ function clean() {
     apothecaryDependencies clean
 
     # cairo
-    make clean
+    rm -rf "build_${TYPE}_${PLATFORM}"
 }
 
 function load() {

--- a/apothecary/formulas/curl/curl.sh
+++ b/apothecary/formulas/curl/curl.sh
@@ -6,7 +6,7 @@
 #
 # uses a CMake build system
 
-FORMULA_TYPES=("vs" "osx" "ios" "xros" "tvos" "catos" "watchos" "android")
+FORMULA_TYPES=("vs" "osx" "ios" "xros" "tvos" "catos" "watchos" "android" "linux")
 FORMULA_DEPENDS=("openssl" "zlib" "brotli" "nghttp2" "nghttp3" "ngtcp2" "libssh2")
 
 # Android to implementation 'com.android.ndk.thirdparty:curl:7.79.1-beta-1'
@@ -83,6 +83,38 @@ function merge_unix_curl_dependencies() {
         local MERGED_LIBRARY="${CURL_LIBRARY}.merged"
         /usr/bin/libtool -static -o "$MERGED_LIBRARY" "$CURL_LIBRARY" "$@"
         mv "$MERGED_LIBRARY" "$CURL_LIBRARY"
+    elif [ "$TYPE" == "linux" ]; then
+        local MERGE_SCRIPT="${CURL_LIBRARY}.mri"
+        local MERGED_LIBRARY="${CURL_LIBRARY}.merged"
+        local ARCHIVER="${AR:-}"
+        local RANLIB_TOOL="${RANLIB:-}"
+        if [ -z "$ARCHIVER" ] && [ -n "${TOOLCHAIN_PREFIX:-}" ]; then
+            ARCHIVER=$(command -v "${TOOLCHAIN_PREFIX}-ar" || true)
+        fi
+        if [ -z "$RANLIB_TOOL" ] && [ -n "${TOOLCHAIN_PREFIX:-}" ]; then
+            RANLIB_TOOL=$(command -v "${TOOLCHAIN_PREFIX}-ranlib" || true)
+        fi
+        ARCHIVER=${ARCHIVER:-$(command -v ar)}
+        RANLIB_TOOL=${RANLIB_TOOL:-$(command -v ranlib)}
+        if [ -z "$ARCHIVER" ] || [ -z "$RANLIB_TOOL" ]; then
+            echo "Unable to find the Linux archive tools"
+            exit 1
+        fi
+        rm -f "$MERGED_LIBRARY" "$MERGE_SCRIPT"
+        {
+            echo "create $MERGED_LIBRARY"
+            echo "addlib $CURL_LIBRARY"
+            local DEPENDENCY
+            for DEPENDENCY in "$@"; do
+                echo "addlib $DEPENDENCY"
+            done
+            echo save
+            echo end
+        } >"$MERGE_SCRIPT"
+        "$ARCHIVER" -M <"$MERGE_SCRIPT"
+        "$RANLIB_TOOL" "$MERGED_LIBRARY"
+        mv "$MERGED_LIBRARY" "$CURL_LIBRARY"
+        rm -f "$MERGE_SCRIPT"
     else
         local MERGE_SCRIPT="${CURL_LIBRARY}.mri"
         local MERGED_LIBRARY="${CURL_LIBRARY}.merged"
@@ -438,6 +470,84 @@ function build() {
             "$NGTCP2_CRYPTO_LIBRARY" "$LIBSSH2_LIBRARY"
         cd ..
 
+    elif [ "$TYPE" == "linux" ]; then
+        CACERT_PATH=$(realpath "$CACERT_PATH")
+        OPENSSL_ROOT="$LIBS_ROOT/openssl"
+        OPENSSL_LIBRARY="$OPENSSL_ROOT/lib/$TYPE/$PLATFORM/libssl.a"
+        OPENSSL_LIBRARY_CRYPT="$OPENSSL_ROOT/lib/$TYPE/$PLATFORM/libcrypto.a"
+        ZLIB_ROOT="$LIBS_ROOT/zlib"
+        ZLIB_LIBRARY="$ZLIB_ROOT/lib/$TYPE/$PLATFORM/zlib.a"
+        LIBBROTLI_ROOT="$LIBS_ROOT/brotli"
+        LIBBROTLI_LIBRARY="$LIBBROTLI_ROOT/lib/$TYPE/$PLATFORM/libbrotlicommon.a"
+        LIBBROTLI_DEC_LIB="$LIBBROTLI_ROOT/lib/$TYPE/$PLATFORM/libbrotlidec.a"
+        NGHTTP2_LIBRARY="$NGHTTP2_ROOT/lib/$TYPE/$PLATFORM/nghttp2.a"
+        NGHTTP3_LIBRARY="$NGHTTP3_ROOT/lib/$TYPE/$PLATFORM/nghttp3.a"
+        NGTCP2_LIBRARY="$NGTCP2_ROOT/lib/$TYPE/$PLATFORM/ngtcp2.a"
+        NGTCP2_CRYPTO_LIBRARY="$NGTCP2_ROOT/lib/$TYPE/$PLATFORM/ngtcp2_crypto_ossl.a"
+        LIBSSH2_LIBRARY="$LIBSSH2_ROOT/lib/$TYPE/$PLATFORM/libssh2.a"
+        local BUILD_DIR="build_${TYPE}_${PLATFORM}"
+
+        rm -rf "$BUILD_DIR"
+        cmake -S . -B "$BUILD_DIR" \
+            -DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/linux${PLATFORM}.toolchain.cmake" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$BUILD_DIR/Release" \
+            -DCMAKE_INSTALL_INCLUDEDIR=include \
+            -DCMAKE_INSTALL_LIBDIR=lib \
+            -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DBUILD_STATIC_LIBS=ON \
+            -DBUILD_STATIC_CURL=ON \
+            -DBUILD_CURL_EXE=OFF \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_TESTING=OFF \
+            -DCURL_STATICLIB=ON \
+            -DCURL_USE_OPENSSL=ON \
+            -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT" \
+            -DOPENSSL_INCLUDE_DIR="$OPENSSL_ROOT/include" \
+            -DOPENSSL_SSL_LIBRARY="$OPENSSL_LIBRARY" \
+            -DOPENSSL_CRYPTO_LIBRARY="$OPENSSL_LIBRARY_CRYPT" \
+            -DOPENSSL_USE_STATIC_LIBS=ON \
+            -DCURL_CA_FALLBACK=ON \
+            -DCURL_CA_BUNDLE="$CACERT_PATH" \
+            -DCURL_CA_EMBED="$CACERT_PATH" \
+            -DZLIB_ROOT="$ZLIB_ROOT" \
+            -DZLIB_INCLUDE_DIR="$ZLIB_ROOT/include" \
+            -DZLIB_LIBRARY="$ZLIB_LIBRARY" \
+            -DCURL_BROTLI=ON \
+            -DBROTLI_INCLUDE_DIR="$LIBBROTLI_ROOT/include" \
+            -DBROTLIDEC_LIBRARY="$LIBBROTLI_DEC_LIB" \
+            -DBROTLICOMMON_LIBRARY="$LIBBROTLI_LIBRARY" \
+            -DUSE_NGHTTP2=ON \
+            -DNGHTTP2_USE_STATIC_LIBS=ON \
+            -DNGHTTP2_INCLUDE_DIR="$NGHTTP2_ROOT/include" \
+            -DNGHTTP2_LIBRARY="$NGHTTP2_LIBRARY" \
+            -DUSE_NGTCP2=ON \
+            -DNGTCP2_USE_STATIC_LIBS=ON \
+            -DNGTCP2_INCLUDE_DIR="$NGTCP2_ROOT/include" \
+            -DNGTCP2_LIBRARY="$NGTCP2_LIBRARY" \
+            -DNGTCP2_CRYPTO_OSSL_LIBRARY="$NGTCP2_CRYPTO_LIBRARY" \
+            -DNGHTTP3_USE_STATIC_LIBS=ON \
+            -DNGHTTP3_INCLUDE_DIR="$NGHTTP3_ROOT/include" \
+            -DNGHTTP3_LIBRARY="$NGHTTP3_LIBRARY" \
+            -DCURL_USE_LIBSSH2=ON \
+            -DLIBSSH2_INCLUDE_DIR="$LIBSSH2_ROOT/include" \
+            -DLIBSSH2_LIBRARY="$LIBSSH2_LIBRARY" \
+            -DCURL_USE_LIBPSL=OFF \
+            -DUSE_LIBIDN2=OFF \
+            -DCURL_ZSTD=OFF \
+            -DENABLE_ARES=OFF \
+            -DENABLE_THREADED_RESOLVER=ON \
+            -DENABLE_IPV6=ON \
+            -DENABLE_WEBSOCKETS=ON
+
+        verify_required_features "$BUILD_DIR/lib/curl_config.h"
+        cmake --build "$BUILD_DIR" --config Release -j"${PARALLEL_MAKE}" --target install
+        merge_unix_curl_dependencies "$BUILD_DIR/Release/lib/libcurl.a" \
+            "$NGHTTP2_LIBRARY" "$NGHTTP3_LIBRARY" "$NGTCP2_LIBRARY" \
+            "$NGTCP2_CRYPTO_LIBRARY" "$LIBSSH2_LIBRARY"
+
     elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos)$ ]]; then
 
         export OPENSSL_LIBRARIES="$OF_LIBS_OPENSSL_ABS_PATH/lib/$TYPE/$PLATFORM"
@@ -657,7 +767,7 @@ function copy() {
         cp -Rv "build_${TYPE}_${PLATFORM}/Release/bin/"* $1/bin
         cp -v "$CURL_APPLE_LIBRARY" $1/lib/$TYPE/$PLATFORM/curl.a
         secure "$1/lib/$TYPE/$PLATFORM/curl.a" "curl.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "${FORMULA_DEPENDS[*]}"
-    elif [ "$TYPE" == "android" ]; then
+    elif [ "$TYPE" == "android" ] || [ "$TYPE" == "linux" ]; then
         mkdir -p $1/lib/$TYPE/$PLATFORM/
         cp -Rv "build_${TYPE}_${PLATFORM}/Release/include/"* $1/include
         mkdir -p $1/bin
@@ -674,7 +784,7 @@ function copy() {
 
 # executed inside the lib src dir
 function clean() {
-    if [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos|emscripten|android)$ ]]; then
+    if [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos|emscripten|android|linux)$ ]]; then
         if [ -d "build_${TYPE}_${PLATFORM}" ]; then
             rm -r build_${TYPE}_${PLATFORM}
         fi

--- a/apothecary/formulas/curl/curl.sh
+++ b/apothecary/formulas/curl/curl.sh
@@ -490,6 +490,9 @@ function build() {
         rm -rf "$BUILD_DIR"
         cmake -S . -B "$BUILD_DIR" \
             -DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/linux${PLATFORM}.toolchain.cmake" \
+            -DCMAKE_C_STANDARD="${C_STANDARD}" \
+            -DCMAKE_CXX_STANDARD="${CPP_STANDARD}" \
+            -DCMAKE_CXX_STANDARD_REQUIRED=ON \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="$BUILD_DIR/Release" \
             -DCMAKE_INSTALL_INCLUDEDIR=include \
@@ -536,6 +539,8 @@ function build() {
             -DLIBSSH2_LIBRARY="$LIBSSH2_LIBRARY" \
             -DCURL_USE_LIBPSL=OFF \
             -DUSE_LIBIDN2=OFF \
+            -DCURL_DISABLE_LDAP=ON \
+            -DCURL_DISABLE_LDAPS=ON \
             -DCURL_ZSTD=OFF \
             -DENABLE_ARES=OFF \
             -DENABLE_THREADED_RESOLVER=ON \

--- a/apothecary/formulas/libssh2.sh
+++ b/apothecary/formulas/libssh2.sh
@@ -3,7 +3,7 @@
 # libssh2 - SSH2 client library used by curl for SCP and SFTP
 # https://github.com/libssh2/libssh2
 
-FORMULA_TYPES=("vs" "osx" "ios" "xros" "tvos" "catos" "watchos" "android")
+FORMULA_TYPES=("vs" "osx" "ios" "xros" "tvos" "catos" "watchos" "android" "linux")
 FORMULA_DEPENDS=("zlib" "openssl")
 
 VER=1.11.1
@@ -85,6 +85,13 @@ function build() {
             -DANDROID_ABI="$ABI"
             -DANDROID_API="$ANDROID_API"
             -DANDROID_NDK_ROOT="$ANDROID_NDK_ROOT"
+            -DOPENSSL_SSL_LIBRARY="$OPENSSL_ROOT/lib/$TYPE/$PLATFORM/libssl.a"
+            -DOPENSSL_CRYPTO_LIBRARY="$OPENSSL_ROOT/lib/$TYPE/$PLATFORM/libcrypto.a"
+            -DZLIB_LIBRARY="$ZLIB_ROOT/lib/$TYPE/$PLATFORM/zlib.a"
+        )
+    elif [ "$TYPE" == "linux" ]; then
+        PLATFORM_ARGS=(
+            -DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/linux${PLATFORM}.toolchain.cmake"
             -DOPENSSL_SSL_LIBRARY="$OPENSSL_ROOT/lib/$TYPE/$PLATFORM/libssl.a"
             -DOPENSSL_CRYPTO_LIBRARY="$OPENSSL_ROOT/lib/$TYPE/$PLATFORM/libcrypto.a"
             -DZLIB_LIBRARY="$ZLIB_ROOT/lib/$TYPE/$PLATFORM/zlib.a"

--- a/apothecary/formulas/libusb/CMakeLists.txt
+++ b/apothecary/formulas/libusb/CMakeLists.txt
@@ -115,6 +115,10 @@ else()
     add_library(usb-1.0 STATIC)
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_compile_definitions(usb-1.0 PRIVATE _GNU_SOURCE)
+endif()
+
 set_target_properties(usb-1.0 PROPERTIES
     PREFIX lib # to be consistent with mainline libusb build system(s)
 )

--- a/apothecary/formulas/libusb/libusb.sh
+++ b/apothecary/formulas/libusb/libusb.sh
@@ -3,7 +3,7 @@
 # libusb for ofxKinect needed for
 # Visual Studio and OS X
 
-FORMULA_TYPES=("osx" "vs")
+FORMULA_TYPES=("osx" "vs" "linux")
 FORMULA_DEPENDS=()
 
 GIT_URL=https://github.com/libusb/libusb
@@ -29,7 +29,7 @@ function download() {
         mv libusb-${VER} libusb
     fi
 
-    if [ "$TYPE" == "osx" ]; then
+    if [ "$TYPE" == "osx" ] || [ "$TYPE" == "linux" ]; then
         downloader "${URL}.tar.gz"
         verify_sha256 "v${VER}.tar.gz" "$SHA256"
         tar -xzf v${VER}.tar.gz
@@ -136,6 +136,20 @@ function build() {
         cd ..
     fi
 
+    if [ "$TYPE" == "linux" ]; then
+        cmake -S . -B "build_${TYPE}_${PLATFORM}" \
+            -DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/linux${PLATFORM}.toolchain.cmake" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="build_${TYPE}_${PLATFORM}/Release" \
+            -DCMAKE_INSTALL_LIBDIR=lib \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DLIBUSB_BUILD_TESTING=OFF \
+            -DLIBUSB_BUILD_EXAMPLES=OFF \
+            -DLIBUSB_INSTALL_TARGETS=ON \
+            -DLIBUSB_BUILD_SHARED_LIBS=OFF
+        cmake --build "build_${TYPE}_${PLATFORM}" -j"${PARALLEL_MAKE}" --target install
+    fi
+
 }
 
 # executed inside the lib src dir, first arg $1 is the dest libs dir root
@@ -152,7 +166,7 @@ function copy() {
         cp -f "build_${TYPE}_${PLATFORM}/Release/libusb-1.0.lib" $1/lib/$TYPE/$PLATFORM/libusb.lib
         secure "$1/lib/$TYPE/$PLATFORM/libusb.lib" "libusb.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
     fi
-    if [ "$TYPE" == "osx" ]; then
+    if [ "$TYPE" == "osx" ] || [ "$TYPE" == "linux" ]; then
         mkdir -p $1/lib/$TYPE/$PLATFORM/
         cp -Rv "build_${TYPE}_${PLATFORM}/Release/include/libusb-1.0/" $1/
         cp -v "build_${TYPE}_${PLATFORM}/Release/lib/libusb-1.0.a" $1/lib/$TYPE/$PLATFORM/libusb.a
@@ -174,7 +188,7 @@ function clean() {
         rm -f *.lib
 
     fi
-    if [ "$TYPE" == "osx" ]; then
+    if [ "$TYPE" == "osx" ] || [ "$TYPE" == "linux" ]; then
         rm -f *.a
     fi
 

--- a/apothecary/formulas/libusb/libusb.sh
+++ b/apothecary/formulas/libusb/libusb.sh
@@ -139,6 +139,9 @@ function build() {
     if [ "$TYPE" == "linux" ]; then
         cmake -S . -B "build_${TYPE}_${PLATFORM}" \
             -DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/linux${PLATFORM}.toolchain.cmake" \
+            -DCMAKE_C_STANDARD="${C_STANDARD}" \
+            -DCMAKE_CXX_STANDARD="${CPP_STANDARD}" \
+            -DCMAKE_CXX_STANDARD_REQUIRED=ON \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="build_${TYPE}_${PLATFORM}/Release" \
             -DCMAKE_INSTALL_LIBDIR=lib \

--- a/apothecary/formulas/libusb/libusb.sh
+++ b/apothecary/formulas/libusb/libusb.sh
@@ -43,9 +43,9 @@ function download() {
 function prepare() {
     cp -f $FORMULA_DIR/CMakeLists.txt .
 
-    if [ "$TYPE" == "vs" ]; then
+    if [ "$TYPE" == "vs" ] || [ "$TYPE" == "linux" ]; then
         cp -f $FORMULA_DIR/config.h.in ./config.h.in
-    else
+    elif [ "$TYPE" == "osx" ]; then
         cp -f ./Xcode/config.h ./config.h
     fi
 }

--- a/apothecary/formulas/nghttp2.sh
+++ b/apothecary/formulas/nghttp2.sh
@@ -3,7 +3,7 @@
 # nghttp2 - HTTP/2 C library
 # https://github.com/nghttp2/nghttp2
 
-FORMULA_TYPES=("vs" "osx" "ios" "xros" "tvos" "catos" "watchos" "android")
+FORMULA_TYPES=("vs" "osx" "ios" "xros" "tvos" "catos" "watchos" "android" "linux")
 FORMULA_DEPENDS=()
 
 VER=1.70.0
@@ -47,6 +47,10 @@ function build() {
             -DANDROID_ABI="$ABI"
             -DANDROID_API="$ANDROID_API"
             -DANDROID_NDK_ROOT="$ANDROID_NDK_ROOT"
+        )
+    elif [ "$TYPE" == "linux" ]; then
+        platform_args=(
+            -DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/linux${PLATFORM}.toolchain.cmake"
         )
     else
         platform_args=(

--- a/apothecary/formulas/nghttp3.sh
+++ b/apothecary/formulas/nghttp3.sh
@@ -3,7 +3,7 @@
 # nghttp3 - HTTP/3 and QPACK library
 # https://github.com/ngtcp2/nghttp3
 
-FORMULA_TYPES=("vs" "osx" "ios" "xros" "tvos" "catos" "watchos" "android")
+FORMULA_TYPES=("vs" "osx" "ios" "xros" "tvos" "catos" "watchos" "android" "linux")
 FORMULA_DEPENDS=()
 
 VER=1.18.0
@@ -41,6 +41,10 @@ function build() {
             -DANDROID_ABI="$ABI"
             -DANDROID_API="$ANDROID_API"
             -DANDROID_NDK_ROOT="$ANDROID_NDK_ROOT"
+        )
+    elif [ "$TYPE" == "linux" ]; then
+        platform_args=(
+            -DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/linux${PLATFORM}.toolchain.cmake"
         )
     else
         platform_args=(

--- a/apothecary/formulas/ngtcp2.sh
+++ b/apothecary/formulas/ngtcp2.sh
@@ -3,7 +3,7 @@
 # ngtcp2 - QUIC transport library with the OpenSSL 3.5+ crypto helper
 # https://github.com/ngtcp2/ngtcp2
 
-FORMULA_TYPES=("vs" "osx" "ios" "xros" "tvos" "catos" "watchos" "android")
+FORMULA_TYPES=("vs" "osx" "ios" "xros" "tvos" "catos" "watchos" "android" "linux")
 FORMULA_DEPENDS=("openssl")
 
 VER=1.25.0
@@ -74,6 +74,12 @@ function build() {
             -DANDROID_ABI="$ABI"
             -DANDROID_API="$ANDROID_API"
             -DANDROID_NDK_ROOT="$ANDROID_NDK_ROOT"
+            -DOPENSSL_SSL_LIBRARY="$OPENSSL_ROOT/lib/$TYPE/$PLATFORM/libssl.a"
+            -DOPENSSL_CRYPTO_LIBRARY="$OPENSSL_ROOT/lib/$TYPE/$PLATFORM/libcrypto.a"
+        )
+    elif [ "$TYPE" == "linux" ]; then
+        PLATFORM_ARGS=(
+            -DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/linux${PLATFORM}.toolchain.cmake"
             -DOPENSSL_SSL_LIBRARY="$OPENSSL_ROOT/lib/$TYPE/$PLATFORM/libssl.a"
             -DOPENSSL_CRYPTO_LIBRARY="$OPENSSL_ROOT/lib/$TYPE/$PLATFORM/libcrypto.a"
         )

--- a/apothecary/formulas/opencv/opencv.sh
+++ b/apothecary/formulas/opencv/opencv.sh
@@ -489,6 +489,17 @@ function build() {
             mv "Debug3rd" build_${TYPE}_${PLATFORM}/3rdparty/lib/Debug
         fi
 
+    elif [ "$TYPE" == "linux" ]; then
+        mkdir -p "$1/lib/$TYPE/$PLATFORM"
+        cp -Rv "build_${TYPE}_${PLATFORM}/Release/include/opencv4/" "$1/include/"
+        cp -v "build_${TYPE}_${PLATFORM}/Release/lib/"*.a "$1/lib/$TYPE/$PLATFORM/"
+        if compgen -G "build_${TYPE}_${PLATFORM}/Release/lib/opencv4/3rdparty/*.a" >/dev/null; then
+            cp -v "build_${TYPE}_${PLATFORM}/Release/lib/opencv4/3rdparty/"*.a "$1/lib/$TYPE/$PLATFORM/"
+        fi
+        if [ -d "build_${TYPE}_${PLATFORM}/Release/share/opencv4" ]; then
+            cp -Rv "build_${TYPE}_${PLATFORM}/Release/share/opencv4/"* "$1/etc/"
+        fi
+        secure "$1/lib/$TYPE/$PLATFORM/libopencv_core.a" "opencv.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
     elif [ "$TYPE" == "android" ]; then
         export ANDROID_NDK=${NDK_ROOT}
 
@@ -1029,7 +1040,7 @@ function clean() {
         if [ -d "build_${TYPE}_${PLATFORM}" ]; then
             rm -r build_${TYPE}_${PLATFORM}
         fi
-    elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos|emscripten)$ ]]; then
+    elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos|emscripten|linux)$ ]]; then
         if [ -d "build_${TYPE}_${PLATFORM}" ]; then
             rm -r build_${TYPE}_${PLATFORM}
         fi

--- a/apothecary/formulas/pixman/pixman.sh
+++ b/apothecary/formulas/pixman/pixman.sh
@@ -3,7 +3,7 @@
 # a low-level software library for pixel manipulation
 # http://pixman.org/
 
-FORMULA_TYPES=("osx" "vs")
+FORMULA_TYPES=("osx" "vs" "linux")
 FORMULA_DEPENDS=()
 
 # define the version
@@ -73,13 +73,25 @@ function prepare() {
 # executed inside the lib src dir
 function build() {
     mkdir -p pixman
-    if [ "$TYPE" == "osx" ]; then
+    if [ "$TYPE" == "osx" ] || [ "$TYPE" == "linux" ]; then
         echo "building $TYPE | $PLATFORM"
         echo "--------------------"
 
         mkdir -p "build_${TYPE}_${PLATFORM}"
         cd "build_${TYPE}_${PLATFORM}"
         rm -f CMakeCache.txt *.a *.o
+        local PLATFORM_DEFS=()
+        if [ "$TYPE" == "osx" ]; then
+            PLATFORM_DEFS=(
+                -DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/ios.toolchain.cmake"
+                -DPLATFORM="$PLATFORM"
+                -DENABLE_BITCODE=OFF
+                -DENABLE_ARC=OFF
+                -DDEPLOYMENT_TARGET="$MIN_SDK_VER"
+            )
+        else
+            PLATFORM_DEFS=(-DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/linux${PLATFORM}.toolchain.cmake")
+        fi
         cmake .. \
             -DCMAKE_C_STANDARD=${C_STANDARD} \
             -DCMAKE_CXX_STANDARD=${CPP_STANDARD} \
@@ -98,11 +110,7 @@ function build() {
             -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=bin \
             -DCMAKE_CXX_FLAGS_RELEASE="-DUSE_PTHREADS=1 ${FLAG_RELEASE}" \
             -DCMAKE_C_FLAGS_RELEASE="-DUSE_PTHREADS=1 ${FLAG_RELEASE} " \
-            -DCMAKE_TOOLCHAIN_FILE=$APOTHECARY_DIR/toolchains/ios.toolchain.cmake \
-            -DPLATFORM=$PLATFORM \
-            -DENABLE_BITCODE=OFF \
-            -DENABLE_ARC=OFF \
-            -DDEPLOYMENT_TARGET=${MIN_SDK_VER} \
+            "${PLATFORM_DEFS[@]}" \
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
             -DCMAKE_MINIMUM_REQUIRED_VERSION=3.22 \
             -DENABLE_VISIBILITY=OFF \
@@ -180,8 +188,7 @@ function copy() {
 
 # executed inside the lib src dir
 function clean() {
-    make uninstall
-    make clean
+    rm -rf "build_${TYPE}_${PLATFORM}"
 }
 
 function load() {

--- a/apothecary/formulas/portaudio.sh
+++ b/apothecary/formulas/portaudio.sh
@@ -6,7 +6,7 @@
 #
 # build not currently needed on any platform
 
-FORMULA_TYPES=("")
+FORMULA_TYPES=("linux")
 FORMULA_DEPENDS=()
 
 # define the version
@@ -35,7 +35,18 @@ function prepare() {
 
 # executed inside the lib src dir
 function build() {
-    echo "build not needed for $TYPE"
+    local HOST_ARGS=()
+    if [ -n "${TOOLCHAIN_PREFIX:-}" ]; then
+        HOST_ARGS=(--host="$TOOLCHAIN_PREFIX")
+    fi
+    ./configure \
+        "${HOST_ARGS[@]}" \
+        --prefix="$PWD/build_${TYPE}_${PLATFORM}/Release" \
+        --disable-shared \
+        --enable-static \
+        --without-jack
+    make -j"${PARALLEL_MAKE}"
+    make install
 }
 
 # executed inside the lib src dir, first arg $1 is the dest libs dir root
@@ -44,6 +55,10 @@ function copy() {
     # headers
     mkdir -p $1/include
     cp -Rv include/* $1/include
+    mkdir -p "$1/lib/$TYPE/$PLATFORM"
+    cp -v "build_${TYPE}_${PLATFORM}/Release/lib/libportaudio.a" "$1/lib/$TYPE/$PLATFORM/libportaudio.a"
+    . "$SECURE_SCRIPT"
+    secure "$1/lib/$TYPE/$PLATFORM/libportaudio.a" "portaudio.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
 
     # copy license file
     if [ -d "$1/license" ]; then
@@ -55,5 +70,5 @@ function copy() {
 
 # executed inside the lib src dir
 function clean() {
-    : # noop
+    make clean
 }

--- a/apothecary/formulas/portaudio.sh
+++ b/apothecary/formulas/portaudio.sh
@@ -22,7 +22,10 @@ GIT_TAG=
 # download the source code and unpack it into LIB_NAME
 function download() {
     . "$DOWNLOADER_SCRIPT"
-    downloader http://www.portaudio.com/archives/pa_$VER.tgz
+    if ! downloader "https://files.portaudio.com/archives/pa_$VER.tgz"; then
+        echoWarning "PortAudio download service unavailable; trying legacy archive host"
+        downloader "http://www.portaudio.com/archives/pa_$VER.tgz"
+    fi
     verify_sha256 "pa_$VER.tgz" "$SHA256"
     tar -xf pa_$VER.tgz
     rm pa_$VER.tgz

--- a/apothecary/formulas/portaudio.sh
+++ b/apothecary/formulas/portaudio.sh
@@ -33,16 +33,21 @@ function download() {
 
 # prepare the build environment, executed inside the lib src dir
 function prepare() {
-    : # noop
+    local automake_libdir
+    automake_libdir="$(automake --print-libdir)"
+    cp "$automake_libdir/config.guess" "$automake_libdir/config.sub" .
 }
 
 # executed inside the lib src dir
 function build() {
+    local BUILD_TRIPLET
+    BUILD_TRIPLET="$(gcc -dumpmachine)"
     local HOST_ARGS=()
     if [ -n "${TOOLCHAIN_PREFIX:-}" ]; then
         HOST_ARGS=(--host="$TOOLCHAIN_PREFIX")
     fi
     ./configure \
+        --build="$BUILD_TRIPLET" \
         "${HOST_ARGS[@]}" \
         --prefix="$PWD/build_${TYPE}_${PLATFORM}/Release" \
         --disable-shared \

--- a/apothecary/formulas/pugixml.sh
+++ b/apothecary/formulas/pugixml.sh
@@ -5,7 +5,7 @@
 # http://pugixml.org/
 #
 # uses a makeifle build system
-FORMULA_TYPES=("emscripten" "osx" "vs" "ios" "watchos" "xros" "catos" "tvos" "android")
+FORMULA_TYPES=("emscripten" "osx" "vs" "ios" "watchos" "xros" "catos" "tvos" "android" "linux")
 FORMULA_DEPENDS=()
 
 # define the version by sha
@@ -151,6 +151,15 @@ function build() {
             -DCMAKE_INSTALL_LIBDIR=lib
         cmake --build . --config Release -j${PARALLEL_MAKE} --target install
 
+    elif [ "$TYPE" == "linux" ]; then
+        cmake -S . -B "build_${TYPE}_${PLATFORM}" ${DEFINES} \
+            -DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/linux${PLATFORM}.toolchain.cmake" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="build_${TYPE}_${PLATFORM}/Release" \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DBUILD_TESTS=OFF
+        cmake --build "build_${TYPE}_${PLATFORM}" -j"${PARALLEL_MAKE}" --target install
     elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos)$ ]]; then
         mkdir -p "build_${TYPE}_${PLATFORM}"
         cd "build_${TYPE}_${PLATFORM}"
@@ -197,7 +206,7 @@ function copy() {
         cp -f "build_${TYPE}_${ARCH}/Release/lib/pugixml.lib" $1/lib/$TYPE/$PLATFORM/pugixml.lib
         cp -f "build_${TYPE}_${ARCH}/Debug/lib/pugixml.lib" $1/lib/$TYPE/$PLATFORM/pugixmlD.lib
         secure "$1/lib/$TYPE/$PLATFORM/pugixml.lib" "pugixml.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
-    elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos)$ ]]; then
+    elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos|linux)$ ]]; then
         mkdir -p $1/include
         mkdir -p $1/lib/$TYPE/$PLATFORM/
         cp -R "build_${TYPE}_${PLATFORM}/Release/include/" $1/include
@@ -229,7 +238,7 @@ function clean() {
             # Delete the folder and its contents
             rm -r build_${TYPE}_${ARCH}
         fi
-    elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos|emscripten)$ ]]; then
+    elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos|emscripten|linux)$ ]]; then
         rm -f *.a
         if [ -d "build_${TYPE}_${PLATFORM}" ]; then
             # Delete the folder and its contents

--- a/apothecary/formulas/rtAudio/rtAudio.sh
+++ b/apothecary/formulas/rtAudio/rtAudio.sh
@@ -155,7 +155,7 @@ function build() {
                 -DRTAUDIO_API_PULSE=ON \
                 -DRTAUDIO_API_ALSA=ON \
                 -DRTAUDIO_API_JACK=ON \
-                -DRTAUDIO_API_OSS=ON \
+                -DRTAUDIO_API_OSS=OFF \
                 -DRTAUDIO_API_DS=OFF \
                 -DRTAUDIO_API_ASIO=OFF \
                 -DRTAUDIO_API_WASAPI=OFF \

--- a/apothecary/formulas/uriparser/CMakeLists.txt
+++ b/apothecary/formulas/uriparser/CMakeLists.txt
@@ -42,7 +42,9 @@ project(uriparser
     LANGUAGES
         C
 )
-set(CMAKE_C_STANDARD 90)  # same as C89, value "89" not supported by CMake
+if(NOT DEFINED CMAKE_C_STANDARD)
+	set(CMAKE_C_STANDARD 90)  # same as C89, value "89" not supported by CMake
+endif()
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)  # i.e. -std=c90 rather than default -std=gnu90
 

--- a/apothecary/formulas/uriparser/CMakeLists.txt
+++ b/apothecary/formulas/uriparser/CMakeLists.txt
@@ -46,7 +46,7 @@ if(NOT DEFINED CMAKE_C_STANDARD)
 	set(CMAKE_C_STANDARD 90)  # same as C89, value "89" not supported by CMake
 endif()
 set(CMAKE_C_STANDARD_REQUIRED ON)
-set(CMAKE_C_EXTENSIONS OFF)  # i.e. -std=c90 rather than default -std=gnu90
+set(CMAKE_C_EXTENSIONS OFF)  # Use strict ISO C rather than GNU extensions
 
 # See https://verbump.de/ for what these numbers do
 set(URIPARSER_SO_CURRENT    2)

--- a/apothecary/formulas/uriparser/uriparser.sh
+++ b/apothecary/formulas/uriparser/uriparser.sh
@@ -109,7 +109,7 @@ function build() {
     elif [ "$TYPE" == "linux" ]; then
         cmake -S . -B "build_${TYPE}_${PLATFORM}" ${DEFS} \
             -DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/linux${PLATFORM}.toolchain.cmake" \
-            -DCMAKE_C_STANDARD=99 \
+            -DCMAKE_C_STANDARD=17 \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="build_${TYPE}_${PLATFORM}/Release" \
             -DURIPARSER_ENABLE_INSTALL=ON \

--- a/apothecary/formulas/uriparser/uriparser.sh
+++ b/apothecary/formulas/uriparser/uriparser.sh
@@ -109,7 +109,6 @@ function build() {
     elif [ "$TYPE" == "linux" ]; then
         cmake -S . -B "build_${TYPE}_${PLATFORM}" ${DEFS} \
             -DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/linux${PLATFORM}.toolchain.cmake" \
-            -DCMAKE_C_STANDARD=17 \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="build_${TYPE}_${PLATFORM}/Release" \
             -DURIPARSER_ENABLE_INSTALL=ON \

--- a/apothecary/formulas/uriparser/uriparser.sh
+++ b/apothecary/formulas/uriparser/uriparser.sh
@@ -109,6 +109,7 @@ function build() {
     elif [ "$TYPE" == "linux" ]; then
         cmake -S . -B "build_${TYPE}_${PLATFORM}" ${DEFS} \
             -DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/linux${PLATFORM}.toolchain.cmake" \
+            -DCMAKE_C_STANDARD=99 \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="build_${TYPE}_${PLATFORM}/Release" \
             -DURIPARSER_ENABLE_INSTALL=ON \

--- a/apothecary/formulas/uriparser/uriparser.sh
+++ b/apothecary/formulas/uriparser/uriparser.sh
@@ -4,7 +4,7 @@
 #
 # uses a CMake build system
 
-FORMULA_TYPES=("osx" "vs" "ios" "watchos" "catos" "xros" "tvos" "android" "emscripten")
+FORMULA_TYPES=("osx" "vs" "ios" "watchos" "catos" "xros" "tvos" "android" "emscripten" "linux")
 FORMULA_DEPENDS=()
 
 VER=1.0.2
@@ -106,6 +106,14 @@ function build() {
         cmake --build . --config Release -j${PARALLEL_MAKE} --target install
         cd ..
 
+    elif [ "$TYPE" == "linux" ]; then
+        cmake -S . -B "build_${TYPE}_${PLATFORM}" ${DEFS} \
+            -DCMAKE_TOOLCHAIN_FILE="$APOTHECARY_DIR/toolchains/linux${PLATFORM}.toolchain.cmake" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="build_${TYPE}_${PLATFORM}/Release" \
+            -DURIPARSER_ENABLE_INSTALL=ON \
+            -DBUILD_SHARED_LIBS=OFF
+        cmake --build "build_${TYPE}_${PLATFORM}" -j"${PARALLEL_MAKE}" --target install
     elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos)$ ]]; then
         echo "int main(){return 0;}" >tool/uriparse.c
         mkdir -p "build_${TYPE}_${PLATFORM}"
@@ -185,6 +193,11 @@ function copy() {
         cp -Rv "build_${TYPE}_${PLATFORM}/UriConfig.h" $1/include/uriparser/
         cp -Rv "build_${TYPE}_${PLATFORM}/liburiparser.a" $1/lib/$TYPE/${PLATFORM}/uriparser.a
         secure "$1/lib/$TYPE/$PLATFORM/uriparser.a" "uriparser.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
+    elif [ "$TYPE" == "linux" ]; then
+        cp -R "build_${TYPE}_${PLATFORM}/Release/include/"* "$1/include/"
+        mkdir -p "$1/lib/$TYPE/$PLATFORM/"
+        cp -v "build_${TYPE}_${PLATFORM}/Release/lib/liburiparser.a" "$1/lib/$TYPE/$PLATFORM/liburiparser.a"
+        secure "$1/lib/$TYPE/$PLATFORM/liburiparser.a" "uriparser.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
     elif [ "$TYPE" == "android" ]; then
         cp -R include/uriparser/* $1/include/uriparser/
         mkdir -p $1/lib/$TYPE/$PLATFORM/
@@ -210,7 +223,7 @@ function clean() {
         if [ -d "build_${TYPE}_${ABI}" ]; then
             rm -r build_${TYPE}_${ABI}
         fi
-    elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos|emscripten)$ ]]; then
+    elif [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos|emscripten|linux)$ ]]; then
         if [ -d "build_${TYPE}_${PLATFORM}" ]; then
             rm -r build_${TYPE}_${PLATFORM}
         fi

--- a/scripts/calculate_formulas.sh
+++ b/scripts/calculate_formulas.sh
@@ -72,6 +72,14 @@ FORMULAS=(
     "metalangle"
 )
 
+FORMULAS_MODULAR_ONLY=()
+LINUX_MODULAR_FORMULAS=(
+    pixman pkg-config zlib utf8 boost libpng brotli pugixml freetype libxml2 svgtiny
+    FreeImage assimp glew glfw glm json libusb kiss portaudio rtAudio tess2
+    uriparser opencv cairo fmt openssl nghttp2 nghttp3 ngtcp2 libssh2 curl
+    poco dawn
+)
+
 if [[ "$TARGET" =~ ^(linux)$ ]]; then
     FORMULAS=(
         "pkg-config"
@@ -91,9 +99,18 @@ if [[ "$TARGET" =~ ^(linux)$ ]]; then
         "FreeImage"
         "fmt"
         "uriparser"
+        "openssl"
+        "nghttp2"
+        "nghttp3"
+        "ngtcp2"
+        "libssh2"
+        "curl"
         # dawn: not in core until Linux CI is GCC 11+ (atomic::wait / bit_cast)
         # TYPE=linux ./apo update dawn
     )
+    # Build and publish the networking stack as individual packages without
+    # changing the established openFrameworks Linux core archive yet.
+    FORMULAS_MODULAR_ONLY=("openssl" "nghttp2" "nghttp3" "ngtcp2" "libssh2" "curl")
     if [[ "$TARCH" =~ ^(64|arm64|x86_64)$ ]]; then
         FORMULAS+=(
            # "poco"
@@ -267,9 +284,25 @@ fi
 # and pickles. Do not xcframework or put in the published tarball.
 FORMULAS_INTERNAL=("nghttp2" "nghttp3" "ngtcp2" "libssh2")
 
+formula_is_modular_only() {
+    local name="$1"
+    local f
+    for f in "${FORMULAS_MODULAR_ONLY[@]}"; do
+        if [ "$f" = "$name" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 formula_is_internal() {
     local name="$1"
     local f
+    # Linux publishes the transport libraries as modular packages even though
+    # curl also incorporates them into its convenience static archive.
+    if [ "$TARGET" = "linux" ]; then
+        return 1
+    fi
     for f in "${FORMULAS_INTERNAL[@]}"; do
         if [ "$f" = "$name" ]; then
             return 0

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -84,6 +84,10 @@ LIBS=$(echo "$LIBS" | tr '\n' ' ')
 LIBS=""
 for LIB in "${FORMULAS[@]}"; do
     LIB=$(echo "$LIB" | tr -d '[:space:]')  # Remove all whitespace
+    if formula_is_modular_only "$LIB"; then
+        echo "Skipping modular-only formula '$LIB' from the core archive"
+        continue
+    fi
     if formula_is_internal "$LIB"; then
         echo "Skipping internal formula '$LIB' (merged into curl)"
         continue


### PR DESCRIPTION
## Summary
- add dedicated GCC 14 modular builds for Linux x86_64 and ARM64
- build and publish the portable library set, including Boost 1.87.0 and the full OpenSSL/curl transport stack
- keep OpenSSL, curl, nghttp2, nghttp3, ngtcp2, and libssh2 out of the Linux core archive for now
- extend Linux support for Boost, Cairo, Pixman, libusb, PortAudio, pugixml, uriparser, OpenCV, and curl dependencies
- make the Raspberry Pi workflow build the complete Linux core formula set and upload modular artifacts

## Validation
- shell syntax checks for all modified formulas and scripts
- parsed all GitHub Actions workflow YAML
- scripts/audit-formula-checksums.sh (43/43)
- git diff --check
- synthetic modular packaging verified for the complete Linux formula list

## Notes
This is a draft so the new native x86_64 and ARM64 jobs can validate the newly enabled formula paths before merge.