### PR TITLE
FreeImage [3.19.13 -> 3.19.14]

### DIFF
--- a/apothecary/formulas/FreeImage/FreeImage.sh
+++ b/apothecary/formulas/FreeImage/FreeImage.sh
@@ -12,11 +12,11 @@ FORMULA_TYPES=("osx" "vs" "ios" "watchos" "catos" "xros" "tvos" "android" "emscr
 
 FORMULA_DEPENDS=("zlib" "libpng")
 
-VER=3.19.13
-SHA256="499a4692b16aab3248e1474f6391f61690a37f8d1f50793d2c06177ef7c346e9"
+VER=3.19.14
+SHA256="2dcc823d744706f71006b13ddb6ea6278628d083f04836cdb7196d25fb4511fe"
 GIT_URL=https://github.com/danoli3/FreeImage
 GIT_TAG=$VER
-BUILD_ID=9
+BUILD_ID=10
 DEFINES=""
 
 # download the source code and unpack it into LIB_NAME
@@ -519,4 +519,3 @@ function clean() {
         clean.sh
     fi
 }
-

--- a/apothecary/formulas/openssl/openssl.sh
+++ b/apothecary/formulas/openssl/openssl.sh
@@ -175,8 +175,12 @@ function build() {
         ZLIB_LIBRARY="$LIBS_ROOT/zlib/lib/$TYPE/$PLATFORM/zlib.a"
         echo "building $TYPE | $PLATFORM"
         echo "--------------------"
-        mkdir -p "build_${TYPE}_${PLATFORM}"
-        cd "build_${TYPE}_${PLATFORM}"
+        BUILD_SUBDIR="build_${TYPE}_${PLATFORM}"
+        if [ "$TYPE" == "catos" ]; then
+            BUILD_SUBDIR="${BUILD_SUBDIR}_${ARCH}"
+        fi
+        mkdir -p "$BUILD_SUBDIR"
+        cd "$BUILD_SUBDIR"
 
         # if [[ "$TYPE" =~ ^(tvos|xros|catos|watchos)$ ]]; then
         # 	# LANG=C sed -i -- 's/define HAVE_FORK 1/define HAVE_FORK 0/' "./openssl/apps/speed.c"
@@ -467,20 +471,24 @@ function copy() {
     . "$SECURE_SCRIPT"
     if [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos|linux)$ ]]; then
 
+        BUILD_SUBDIR="build_${TYPE}_${PLATFORM}"
+        if [ "$TYPE" == "catos" ]; then
+            BUILD_SUBDIR="${BUILD_SUBDIR}_${ARCH}"
+        fi
         mkdir -p $1/include
         mkdir -p $1/lib/$TYPE
         mkdir -p $1/lib/$TYPE/$PLATFORM/
-        echo "cppy: build_${TYPE}_${PLATFORM}/Release/lib/libcrypto.a"
-        cp -v "build_${TYPE}_${PLATFORM}/Release/lib/libcrypto.a" $1/lib/$TYPE/$PLATFORM/libcrypto.a
-        cp -v "build_${TYPE}_${PLATFORM}/Release/lib/libssl.a" $1/lib/$TYPE/$PLATFORM/libssl.a
-        cp -Rv "build_${TYPE}_${PLATFORM}/Release/include" $1/
+        echo "copy: ${BUILD_SUBDIR}/Release/lib/libcrypto.a"
+        cp -v "${BUILD_SUBDIR}/Release/lib/libcrypto.a" $1/lib/$TYPE/$PLATFORM/libcrypto.a
+        cp -v "${BUILD_SUBDIR}/Release/lib/libssl.a" $1/lib/$TYPE/$PLATFORM/libssl.a
+        cp -Rv "${BUILD_SUBDIR}/Release/include" $1/
 
         secure "$1/lib/$TYPE/$PLATFORM/libssl.a" "openssl.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
         secure "$1/lib/$TYPE/$PLATFORM/libcrypto.a" "crypto.pkl" "$VERSION" "$DEFINES" "$BUILD_ID" "$FORMULA_DEPENDS"
 
-        cp -vR "build_${TYPE}_${PLATFORM}/Release/lib/pkgconfig/openssl.pc" $1/lib/$TYPE/$PLATFORM/openssl.pc
-        cp -vR "build_${TYPE}_${PLATFORM}/Release/lib/pkgconfig/libcrypto.pc" $1/lib/$TYPE/$PLATFORM/libcrypto.pc
-        cp -vR "build_${TYPE}_${PLATFORM}/Release/lib/pkgconfig/libssl.pc" $1/lib/$TYPE/$PLATFORM/libssl.pc
+        cp -vR "${BUILD_SUBDIR}/Release/lib/pkgconfig/openssl.pc" $1/lib/$TYPE/$PLATFORM/openssl.pc
+        cp -vR "${BUILD_SUBDIR}/Release/lib/pkgconfig/libcrypto.pc" $1/lib/$TYPE/$PLATFORM/libcrypto.pc
+        cp -vR "${BUILD_SUBDIR}/Release/lib/pkgconfig/libssl.pc" $1/lib/$TYPE/$PLATFORM/libssl.pc
 
         PKG_FILE="$1/lib/$TYPE/$PLATFORM/openssl.pc"
         sed -i.bak "s|^prefix=.*|prefix=${1}|" "$PKG_FILE"
@@ -604,8 +612,12 @@ function copy() {
 function clean() {
 
     if [[ "$TYPE" =~ ^(osx|ios|tvos|xros|catos|watchos|emscripten|linux)$ ]]; then
-        if [ -d "build_${TYPE}_${PLATFORM}" ]; then
-            rm -r build_${TYPE}_${PLATFORM}
+        BUILD_SUBDIR="build_${TYPE}_${PLATFORM}"
+        if [ "$TYPE" == "catos" ]; then
+            BUILD_SUBDIR="${BUILD_SUBDIR}_${ARCH}"
+        fi
+        if [ -d "$BUILD_SUBDIR" ]; then
+            rm -r "$BUILD_SUBDIR"
         fi
     elif [ "$TYPE" == "vs" ]; then
         if [ -d "build_${TYPE}_${ARCH}" ]; then


### PR DESCRIPTION
## Summary

Updates FreeImage from 3.19.13 to 3.19.14.

- source tag: `3.19.14`
- source commit: `20567538046be15a22978409e79f27c68ca10d6b`
- source archive SHA-256: `2dcc823d744706f71006b13ddb6ea6278628d083f04836cdb7196d25fb4511fe`
- formula build ID: `10`

## FreeImage 3.19.14 release notes

This is a security release that closes the remaining FreeImage-owned CVEs tracked in danoli3/FreeImage#35. Malformed IPTC, Exif, XPM, XBM, RAS, TIFF, and JPEG input that could cause out-of-bounds reads/writes or a JPEG use-after-free is now rejected or bounded.

Patched issues include:

- CVE-2024-9029 / CVE-2024-28568: IPTC one-byte out-of-bounds read
- CVE-2024-28570: Exif MakerNote signature read beyond short tags
- CVE-2024-28573 and CVE-2024-28577: Exif APP1/signature length validation
- CVE-2024-28578 / CVE-2024-28580: RAS loop-counter wrapping and allocation overflow
- CVE-2024-28583: XBM off-by-one stack write
- CVE-2024-28566: TIFF source-strip out-of-bounds copy
- CVE-2024-28571: JPEG error-path use-after-free
- CVE-2024-28572: Canon MakerNote type-safe camera-state indexing
- additional XPM row-length and color-name bounds hardening

Full upstream notes: https://github.com/danoli3/FreeImage/releases/tag/3.19.14
Full changelog: https://github.com/danoli3/FreeImage/compare/3.19.13...3.19.14

## Validation

- downloaded the tagged source archive and independently verified its SHA-256
- `bash -n apothecary/formulas/FreeImage/FreeImage.sh`
- `scripts/audit-formula-checksums.sh` (43/43)