### PR TITLE
Add separate OpenSSL XCFramework products

### DIFF
--- a/apothecary/apothecary
+++ b/apothecary/apothecary
@@ -1836,6 +1836,74 @@ function mergeStaticArchives() {
   mv -f "$tmp" "$dest"
 }
 
+# OpenSSL exposes libssl and libcrypto as separate public link products.
+# Preserve that layout when creating XCFrameworks instead of only publishing
+# the legacy framework that merges every archive belonging to the formula.
+function createOpenSSLProductXCFramework() {
+  local archive_name="$1"
+  local product_name="${archive_name%.a}"
+  local output_type="${TYPE_OUT:-${X_TYPE:-macos}}"
+  local source_root="$LIBS_DIR_REAL/openssl/lib"
+  local output_root="$XLIBS_DIR_REAL/openssl/lib/$output_type"
+  local staging_root="$XLIBS_DIR_REAL/openssl/.xcframework-staging/$product_name"
+  local output_path="$output_root/$product_name.xcframework"
+  local -a product_flags=()
+  local -a platform_types=("ios" "osx" "tvos" "catos" "xros" "watchos")
+  local -A arch_pairs=(
+    ["MAC"]="MAC_ARM64"
+    ["MAC_ARM64"]="MAC"
+    ["MAC_CATALYST"]="MAC_CATALYST_ARM64"
+    ["MAC_CATALYST_ARM64"]="MAC_CATALYST"
+    ["SIMULATOR64"]="SIMULATORARM64"
+    ["SIMULATORARM64"]="SIMULATOR64"
+    ["SIMULATOR_TVOS"]="SIMULATORARM64_TVOS"
+    ["SIMULATORARM64_TVOS"]="SIMULATOR_TVOS"
+    ["TVOS"]="TVOS"
+    ["WATCHOS"]="WATCHOS"
+    ["SIMULATORARM64_WATCHOS"]="SIMULATOR_WATCHOS"
+    ["SIMULATOR_WATCHOS"]="SIMULATORARM64_WATCHOS"
+    ["OS64"]="OS64"
+    ["VISIONOS"]="VISIONOS"
+    ["SIMULATOR64_VISIONOS"]="SIMULATOR_VISIONOS"
+    ["SIMULATOR_VISIONOS"]="SIMULATOR64_VISIONOS"
+  )
+  local -A processed=()
+
+  rm -rf "$staging_root" "$output_path"
+  mkdir -p "$staging_root" "$output_root"
+
+  local current_type arch pair archive_path pair_path product_archive merge_dir
+  for current_type in "${platform_types[@]}"; do
+    for arch in "${!arch_pairs[@]}"; do
+      [ -z "${processed[$current_type/$arch]:-}" ] || continue
+      pair="${arch_pairs[$arch]}"
+      archive_path="$source_root/$current_type/$arch/$archive_name"
+      [ -f "$archive_path" ] || continue
+
+      pair_path="$source_root/$current_type/$pair/$archive_name"
+      product_archive="$archive_path"
+      if [ "$arch" != "$pair" ] && [ -f "$pair_path" ]; then
+        merge_dir="$staging_root/${current_type}_${arch}_${pair}"
+        mkdir -p "$merge_dir"
+        product_archive="$merge_dir/$archive_name"
+        xcrun lipo -create "$archive_path" "$pair_path" -output "$product_archive"
+        processed[$current_type/$pair]=1
+      fi
+
+      product_flags+=( -library "$product_archive" -headers "$LIBS_DIR_REAL/openssl/include" )
+      processed[$current_type/$arch]=1
+    done
+  done
+
+  if [ "${#product_flags[@]}" -eq 0 ]; then
+    echoError "No $archive_name slices found for OpenSSL XCFramework"
+    return 1
+  fi
+
+  xcrun xcodebuild -create-xcframework "${product_flags[@]}" -output "$output_path"
+  echoSuccess "Created separate OpenSSL product: $output_path"
+}
+
 function frameworkFormula() {
 
   echoStart " frameworkFormula [\"$1\"] for:[${TYPE}]"
@@ -2127,6 +2195,12 @@ function frameworkFormula() {
     echoSuccess " xcframework for $TYPE built successfully."
     echo "========================"
 
+    if [ "$1" == "openssl" ]; then
+      createOpenSSLProductXCFramework "libssl.a"
+      createOpenSSLProductXCFramework "libcrypto.a"
+      rm -rf "$XLIBS_DIR_REAL/openssl/.xcframework-staging"
+    fi
+
     cd $HERE_DIR
 
 
@@ -2411,6 +2485,12 @@ function xframeworkFormula() {
     xcodebuild -create-xcframework $xcframework_flags -output $1.xcframework
     echoSuccess " xcframework for $TYPE built successfully."
     echo "========================"
+
+    if [ "$1" == "openssl" ]; then
+      createOpenSSLProductXCFramework "libssl.a"
+      createOpenSSLProductXCFramework "libcrypto.a"
+      rm -rf "$XLIBS_DIR_REAL/openssl/.xcframework-staging"
+    fi
 
     cd $HERE_DIR
 

--- a/scripts/deploy-openframeworks-artifacts.sh
+++ b/scripts/deploy-openframeworks-artifacts.sh
@@ -60,9 +60,11 @@ done < <(find "$STAGING_DIRECTORY" -mindepth 1 -maxdepth 1 -type d -print | sort
     exit 1
 }
 
-[[ -d "$OF_ROOT/libs/openssl/lib/macos/openssl.xcframework" ]] || {
-    echo "deployed artifacts are missing the macOS OpenSSL XCFramework at libs/openssl" >&2
-    exit 1
-}
+for framework in openssl libssl libcrypto; do
+    [[ -d "$OF_ROOT/libs/openssl/lib/macos/$framework.xcframework" ]] || {
+        echo "deployed artifacts are missing $framework.xcframework at libs/openssl/lib/macos" >&2
+        exit 1
+    }
+done
 
 echo "Installed $library_count libraries from $archive_count artifacts into openFrameworks"


### PR DESCRIPTION
Closes #595.

## What changed

- continue publishing the legacy combined `openssl.xcframework` for compatibility
- additionally publish standard `libssl.xcframework` and `libcrypto.xcframework` products
- group archives by basename in the Apple framework pass (`libssl.a`, `libcrypto.a`) instead of combining every `.a` in a slice into `openssl.a` and then trying to recreate the split products
- keep each library name and contents while combining matching Intel/ARM slices
- apply the split-product pass to both the platform framework path and the consolidated macOS `-x` path
- require all three OpenSSL XCFrameworks in the openFrameworks artifact deployment smoke test

This lets consumers such as POCO and CMake FindOpenSSL link SSL and Crypto normally without colliding with a renamed combined archive. Existing consumers of `openssl.xcframework` can migrate separately.

## Validation

- `bash -n apothecary/apothecary scripts/deploy-openframeworks-artifacts.sh`
- `git diff --check`